### PR TITLE
Add `#[diagnostic(transparent)]`

### DIFF
--- a/miette-derive/src/diagnostic.rs
+++ b/miette-derive/src/diagnostic.rs
@@ -43,7 +43,7 @@ pub struct DiagnosticConcreteArgs {
 }
 
 impl DiagnosticConcreteArgs {
-    fn parse<'a>(
+    fn parse(
         ident: &syn::Ident,
         fields: &syn::Fields,
         attr: &syn::Attribute,
@@ -73,7 +73,7 @@ impl DiagnosticConcreteArgs {
                 }
             }
         }
-        let snippets = Snippets::from_fields(&fields)?;
+        let snippets = Snippets::from_fields(fields)?;
         let concrete = DiagnosticConcreteArgs {
             code: code
                 .ok_or_else(|| syn::Error::new(ident.span(), "Diagnostic code is required."))?,
@@ -124,7 +124,7 @@ impl Diagnostic {
             syn::Data::Struct(data_struct) => {
                 if let Some(attr) = input.attrs.iter().find(|x| x.path.is_ident("diagnostic")) {
                     let args =
-                        DiagnosticDefArgs::parse(&input.ident, &data_struct.fields, &attr, true)?;
+                        DiagnosticDefArgs::parse(&input.ident, &data_struct.fields, attr, true)?;
                     Diagnostic::Struct {
                         fields: data_struct.fields,
                         ident: input.ident,
@@ -143,7 +143,7 @@ impl Diagnostic {
                 let mut vars = Vec::new();
                 for var in variants {
                     if let Some(attr) = var.attrs.iter().find(|x| x.path.is_ident("diagnostic")) {
-                        let args = DiagnosticDefArgs::parse(&var.ident, &var.fields, &attr, true)?;
+                        let args = DiagnosticDefArgs::parse(&var.ident, &var.fields, attr, true)?;
                         vars.push(DiagnosticDef {
                             ident: var.ident,
                             fields: var.fields,
@@ -190,7 +190,7 @@ impl Diagnostic {
                         }
                         let field = fields
                             .iter()
-                            .nth(0)
+                            .next()
                             .expect("MIETTE BUG: thought we knew we had exactly one field");
                         let field_name = field
                             .ident

--- a/miette-derive/src/diagnostic.rs
+++ b/miette-derive/src/diagnostic.rs
@@ -16,6 +16,8 @@ pub enum Diagnostic {
         fields: syn::Fields,
         // Nobody needs a transparent wrapper struct for another thing that already
         // implements diagnostic, surely.
+        //
+        // See miette::compile_test::TransparentCombinations;
         args: DiagnosticConcreteArgs,
     },
     Enum {

--- a/miette-derive/src/diagnostic_arg.rs
+++ b/miette-derive/src/diagnostic_arg.rs
@@ -6,6 +6,7 @@ use crate::severity::Severity;
 use crate::url::Url;
 
 pub enum DiagnosticArg {
+    Transparent,
     Code(Code),
     Severity(Severity),
     Help(Help),
@@ -15,7 +16,11 @@ pub enum DiagnosticArg {
 impl Parse for DiagnosticArg {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let ident = input.fork().parse::<syn::Ident>()?;
-        if ident == "code" {
+        if ident == "transparent" {
+            // consume the token
+            let _: syn::Ident = input.parse()?;
+            Ok(DiagnosticArg::Transparent)
+        } else if ident == "code" {
             Ok(DiagnosticArg::Code(input.parse()?))
         } else if ident == "severity" {
             Ok(DiagnosticArg::Severity(input.parse()?))

--- a/miette-derive/src/help.rs
+++ b/miette-derive/src/help.rs
@@ -103,7 +103,7 @@ impl Help {
                      }
                  },
             )
-            .filter_map(|x| x)
+            .flatten()
             .collect::<Vec<_>>();
         if help_pairs.is_empty() {
             None

--- a/miette-derive/src/help.rs
+++ b/miette-derive/src/help.rs
@@ -9,8 +9,11 @@ use syn::{
     Fields, Token,
 };
 
-use crate::diagnostic::DiagnosticVariant;
 use crate::fmt::{self, Display};
+use crate::{
+    diagnostic::{DiagnosticConcreteArgs, DiagnosticDef, DiagnosticDefArgs},
+    utils::forward_to_single_field_variant,
+};
 
 pub struct Help {
     pub display: Display,
@@ -54,46 +57,53 @@ impl Parse for Help {
 }
 
 impl Help {
-    pub(crate) fn gen_enum(variants: &[DiagnosticVariant]) -> Option<TokenStream> {
+    pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {
         let help_pairs = variants
             .iter()
-            .filter(|v| v.help.is_some())
             .map(
-                |DiagnosticVariant {
-                     ref ident,
-                     ref help,
-                     ref fields,
+                |DiagnosticDef {
+                     ident,
+                     fields,
+                     args,
                      ..
                  }| {
-                    let mut display = help.as_ref().expect("already checked for Some").display.clone();
-                    let member_idents = fields.iter().enumerate().map(|(i, field)| {
-                        field
-                            .ident
-                            .as_ref()
-                            .cloned()
-                            .unwrap_or_else(|| format_ident!("_{}", i))
-                    });
-                    let members: HashSet<syn::Member> = fields.iter().enumerate().map(|(i, field)| {
-                        if let Some(ident) = field.ident.as_ref().cloned() {
-                            syn::Member::Named(ident)
-                        } else {
-                            syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-                        }
-                    }).collect();
-                    display.expand_shorthand(&members);
-                    let Display { fmt, args, .. } = display;
-                    match fields {
-                        syn::Fields::Named(_) => {
-                            quote! { Self::#ident{ #(#member_idents),* } => std::option::Option::Some(std::boxed::Box::new(format!(#fmt, #args))), }
-                        }
-                        syn::Fields::Unnamed(_) => {
-                            quote! { Self::#ident( #(#member_idents),* ) => std::option::Option::Some(std::boxed::Box::new(format!(#fmt, #args))), }
-                        }
-                        syn::Fields::Unit =>
-                            quote! { Self::#ident => std::option::Option::Some(std::boxed::Box::new(format!(#fmt, #args))), },
-                    }
+                     match args {
+                         DiagnosticDefArgs::Transparent => {
+                             Some(forward_to_single_field_variant(ident, fields, quote!{ help() } ))
+                         }
+                         DiagnosticDefArgs::Concrete(DiagnosticConcreteArgs { help, .. }) => {
+                             let mut display = help.as_ref()?.display.clone();
+                             let member_idents = fields.iter().enumerate().map(|(i, field)| {
+                                 field
+                                     .ident
+                                     .as_ref()
+                                     .cloned()
+                                     .unwrap_or_else(|| format_ident!("_{}", i))
+                             });
+                             let members: HashSet<syn::Member> = fields.iter().enumerate().map(|(i, field)| {
+                                 if let Some(ident) = field.ident.as_ref().cloned() {
+                                     syn::Member::Named(ident)
+                                 } else {
+                                     syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
+                                 }
+                             }).collect();
+                             display.expand_shorthand(&members);
+                             let Display { fmt, args, .. } = display;
+                             Some(match fields {
+                                 syn::Fields::Named(_) => {
+                                     quote! { Self::#ident{ #(#member_idents),* } => std::option::Option::Some(std::boxed::Box::new(format!(#fmt, #args))), }
+                                 }
+                                 syn::Fields::Unnamed(_) => {
+                                     quote! { Self::#ident( #(#member_idents),* ) => std::option::Option::Some(std::boxed::Box::new(format!(#fmt, #args))), }
+                                 }
+                                 syn::Fields::Unit =>
+                                     quote! { Self::#ident => std::option::Option::Some(std::boxed::Box::new(format!(#fmt, #args))), },
+                             })
+                         }
+                     }
                  },
             )
+            .filter_map(|x| x)
             .collect::<Vec<_>>();
         if help_pairs.is_empty() {
             None

--- a/miette-derive/src/severity.rs
+++ b/miette-derive/src/severity.rs
@@ -82,7 +82,7 @@ impl Severity {
                      }
                 },
             )
-            .filter_map(|x| x)
+            .flatten()
             .collect::<Vec<_>>();
         if sev_pairs.is_empty() {
             None

--- a/miette-derive/src/snippets.rs
+++ b/miette-derive/src/snippets.rs
@@ -415,7 +415,7 @@ impl Snippets {
                 }
             }
         })
-        .filter_map(|x| x);
+        .flatten();
         Some(quote! {
             #[allow(unused_variables)]
             fn snippets(&self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = miette::DiagnosticSnippet> + '_>> {

--- a/miette-derive/src/url.rs
+++ b/miette-derive/src/url.rs
@@ -126,7 +126,7 @@ impl Url {
                 }
             }
          })
-        .filter_map(|x| x)
+        .flatten()
         .collect::<Vec<_>>();
         if url_pairs.is_empty() {
             None

--- a/miette-derive/src/utils.rs
+++ b/miette-derive/src/utils.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{format_ident, quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 
 pub(crate) enum MemberOrString {
@@ -29,6 +29,38 @@ impl Parse for MemberOrString {
                 input.span(),
                 "Expected a string or a field reference.",
             ))
+        }
+    }
+}
+
+// bool here is whether to use curly braces
+pub fn single_field_name(fields: &syn::Fields) -> Option<(bool, &syn::Field)> {
+    match fields {
+        syn::Fields::Named(f) if f.named.len() == 1 => f.named.first().map(|x| (true, x)),
+        syn::Fields::Unnamed(f) if f.unnamed.len() == 1 => f.unnamed.first().map(|x| (false, x)),
+        _ => None,
+    }
+}
+
+// Returns a match arm
+pub fn forward_to_single_field_variant(
+    ident: &syn::Ident,
+    fields: &syn::Fields,
+    method_call: TokenStream,
+) -> TokenStream {
+    if let Some((curly, single_field)) = single_field_name(fields) {
+        let field_name = single_field
+            .ident
+            .clone()
+            .unwrap_or_else(|| format_ident!("unnamed"));
+        if curly {
+            quote! { Self::#ident { #field_name } => #field_name.#method_call, }
+        } else {
+            quote! { Self::#ident(#field_name) => #field_name.#method_call, }
+        }
+    } else {
+        quote! {
+            _ => compile_error!("miette: used `#[diagnostic(transparent)]` on variant without one single field"),
         }
     }
 }

--- a/src/compile_test.rs
+++ b/src/compile_test.rs
@@ -56,7 +56,7 @@
 #[doc(hidden)]
 struct SingleFieldTests;
 
-/// Directly on a struct
+/// Directly on a struct with any other arg
 ///
 /// ```compile_fail
 /// use thiserror::Error;
@@ -67,7 +67,7 @@ struct SingleFieldTests;
 /// struct Foo {}
 /// #[derive(Debug, Diagnostic, Error)]
 /// #[error("welp")]
-/// #[diagnostic(transparent)]
+/// #[diagnostic(transparent, code(invalid::combo))]
 /// struct Bar(Foo);
 /// ```
 ///

--- a/src/compile_test.rs
+++ b/src/compile_test.rs
@@ -1,0 +1,94 @@
+//! A hacky but perfectly good method of adding compile_fail doctests. You can't do this in a
+//! regular tests/blah.rs file.
+
+/// ```compile_fail
+/// use thiserror::Error;
+/// use miette_derive::Diagnostic;
+/// #[derive(Debug, Diagnostic, Error)]
+/// #[error("welp")]
+/// #[diagnostic(code(foo::bar::baz))]
+/// struct Foo {}
+///
+/// #[derive(Debug, Diagnostic, Error)]
+/// enum Variants {
+///     #[error("no")]
+///     #[diagnostic(transparent)]
+///     One,
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use thiserror::Error;
+/// use miette_derive::Diagnostic;
+/// #[derive(Debug, Diagnostic, Error)]
+/// #[error("welp")]
+/// #[diagnostic(code(foo::bar::baz))]
+/// struct Foo {}
+///
+/// #[derive(Debug, Diagnostic, Error)]
+/// enum Variants {
+///     #[error("no")]
+///     #[diagnostic(transparent)]
+///     One {
+///         one: Foo,
+///         two: u32,
+///     },
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use thiserror::Error;
+/// use miette_derive::Diagnostic;
+/// #[derive(Debug, Diagnostic, Error)]
+/// #[error("welp")]
+/// #[diagnostic(code(foo::bar::baz))]
+/// struct Foo {}
+///
+/// #[derive(Debug, Diagnostic, Error)]
+/// enum Variants {
+///     #[error("no")]
+///     #[diagnostic(transparent)]
+///     One(Foo, u32),
+/// }
+/// ```
+///
+#[allow(dead_code)]
+#[doc(hidden)]
+struct SingleFieldTests;
+
+/// Directly on a struct
+///
+/// ```compile_fail
+/// use thiserror::Error;
+/// use miette_derive::Diagnostic;
+/// #[derive(Debug, Diagnostic, Error)]
+/// #[error("welp")]
+/// #[diagnostic(code(foo::bar::baz))]
+/// struct Foo {}
+/// #[derive(Debug, Diagnostic, Error)]
+/// #[error("welp")]
+/// #[diagnostic(transparent)]
+/// struct Bar(Foo);
+/// ```
+///
+/// With any other arg to diagnostic()
+///
+/// ```compile_fail
+/// use thiserror::Error;
+/// use miette_derive::Diagnostic;
+/// #[derive(Debug, Diagnostic, Error)]
+/// #[error("welp")]
+/// #[diagnostic(code(foo::bar::baz))]
+/// struct Foo {}
+///
+/// #[derive(Debug, Diagnostic, Error)]
+/// enum Variants {
+///     #[error("no")]
+///     #[diagnostic(transparent, code(invalid::combo))]
+///     One(Foo),
+/// }
+/// ```
+///
+#[allow(dead_code)]
+#[doc(hidden)]
+struct TransparentCombinations;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,6 @@ mod printer;
 mod protocol;
 mod source_impls;
 mod utils;
+
+#[cfg(doctest)]
+mod compile_test;


### PR DESCRIPTION
Fixes #16.

I struggled hard naming some of the syntax structs/enums so rename them if you can think of something better. I also didn't implement it for single field structs, mainly because I couldn't be bothered. The only reason I can imagine that being useful is wrapping a foreign diagnostic type, and adding impls for std traits like PartialEq, etc. If anyone needs that it wouldn't be hard.