### PR TITLE
Only inc the line count if we haven't already done so with a char

### DIFF
--- a/src/printer/graphical_printer.rs
+++ b/src/printer/graphical_printer.rs
@@ -461,6 +461,7 @@ impl GraphicalReportPrinter {
         let mut lines = Vec::new();
         while let Some(char) = iter.next() {
             offset += char.len_utf8();
+            let mut at_end_of_file = false;
             match char {
                 '\r' => {
                     if iter.next_if_eq(&'\n').is_some() {
@@ -471,8 +472,10 @@ impl GraphicalReportPrinter {
                         line_str.push(char);
                         column += 1;
                     }
+                    at_end_of_file = iter.peek().is_none();
                 }
                 '\n' => {
+                    at_end_of_file = iter.peek().is_none();
                     line += 1;
                     column = 0;
                 }
@@ -481,7 +484,8 @@ impl GraphicalReportPrinter {
                     column += 1;
                 }
             }
-            if iter.peek().is_none() {
+
+            if iter.peek().is_none() && !at_end_of_file {
                 line += 1;
             }
 

--- a/tests/printer.rs
+++ b/tests/printer.rs
@@ -277,7 +277,7 @@ line5
  3 │ ││   line3
  4 │ │├─▶ line4
    · │╰──── block 2
- 6 │ ├──▶ line5
+ 5 │ ├──▶ line5
    · ╰───── block 1
 
     ‽ try doing it better next time?
@@ -329,7 +329,7 @@ line5
  2 │ │╭─▶ line2
  3 │ ││   line3
  4 │ │╰─▶ line4
- 6 │ ├──▶ line5
+ 5 │ ├──▶ line5
    · ╰───── block 1
 
     ‽ try doing it better next time?


### PR DESCRIPTION
The tests reflected the incorrect behaviour, skipping a line at at the very end.