### PR TITLE
Remove bound `T: Clone` from `Source` implementation for `Cow`.

### DIFF
--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -1,7 +1,11 @@
 /*!
 Default trait implementations for [Source].
 */
-use std::{borrow::{Cow, ToOwned}, fmt::Debug, sync::Arc};
+use std::{
+    borrow::{Cow, ToOwned},
+    fmt::Debug,
+    sync::Arc,
+};
 
 use crate::{MietteError, MietteSpanContents, Source, SourceSpan, SpanContents};
 

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -1,7 +1,7 @@
 /*!
 Default trait implementations for [Source].
 */
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::{Cow, ToOwned}, fmt::Debug, sync::Arc};
 
 use crate::{MietteError, MietteSpanContents, Source, SourceSpan, SpanContents};
 
@@ -84,7 +84,12 @@ impl<T: Source> Source for Arc<T> {
     }
 }
 
-impl<T: Source + Clone> Source for Cow<'_, T> {
+impl<T: ?Sized + Source + ToOwned> Source for Cow<'_, T>
+where
+    // The minimal bounds are used here. `T::Owned` need not be `Source`, because `&T` can always
+    // be obtained from `Cow<'_, T>`.
+    T::Owned: Debug + Send + Sync,
+{
     fn read_span<'a>(
         &'a self,
         span: &SourceSpan,


### PR DESCRIPTION
The bound `T: Clone` on [the `Source` implementation for `Cow<'_, T>`](https://github.com/zkat/miette/blob/84219f6c80c2c432fbeb4c40a591380285de8767/src/source_impls.rs#L87) is too restrictive. `Cow<'_, T>` [implements `Clone` using `T: ToOwned`](https://github.com/rust-lang/rust/blob/6cfa773583bb5123e630668f5bfe466716225546/library/alloc/src/borrow.rs#L199) and `T` need not implement `Clone` itself. This change relaxes the bounds so that the `Source` implementation includes `Cow<'_, str>`. Please take a look. Thanks!