### PR TITLE
Fix end of previous line wrongly being included in highlight

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -592,7 +592,7 @@ impl Line {
 
     fn span_applies(&self, span: &FancySpan) -> bool {
         // Span starts in this line
-        (span.offset() >= self.offset && span.offset() <= self.offset +self.length)
+        (span.offset() >= self.offset && span.offset() < self.offset +self.length)
         // Span passes through this line
         || (span.offset() < self.offset && span.offset() + span.len() > self.offset + self.length) //todo
         // Span ends on this line


### PR DESCRIPTION
when the highlight span starts at the very begining of a line, the highlight currently includes the line above

Before:

![image](https://user-images.githubusercontent.com/1283854/132992741-b8b45eb7-4a44-46fe-a508-facfae4a62d5.png)

After:

![image](https://user-images.githubusercontent.com/1283854/132992745-819ac7cc-fe15-4d12-b1f3-d2b75223afbb.png)
