### PR TITLE
Change span_ends to prevent spilling

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -739,7 +739,7 @@ impl Line {
     // Does this line contain the *end* of this multiline span?
     // This assumes self.span_applies() is true already.
     fn span_ends(&self, span: &FancySpan) -> bool {
-        span.offset() + span.len() >= self.offset
+        span.offset() + span.len() > self.offset
             && span.offset() + span.len() <= self.offset + self.length
     }
 }


### PR DESCRIPTION
`span_ends` checks to see if the multiline span ends in this span. If I'm reading this correctly, it would be possible that the end of the span that ends at the previous line unintentionally spills into the next span, if that span starts at the beginning of the next line.

An example: if the offset is 10 and len is 2, we're ending at 12. I believe we don't want to consider the offset 12 to be part of this span, only a possible part of the next span.