### PR TITLE
Fix off-by-one span_applies calculation

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -713,11 +713,11 @@ impl Line {
 
     fn span_applies(&self, span: &FancySpan) -> bool {
         // Span starts in this line
-        (span.offset() >= self.offset && span.offset() < self.offset +self.length)
+        (span.offset() >= self.offset && span.offset() < self.offset + self.length)
         // Span passes through this line
         || (span.offset() < self.offset && span.offset() + span.len() > self.offset + self.length) //todo
         // Span ends on this line
-        || (span.offset() + span.len() >= self.offset && span.offset() + span.len() <= self.offset + self.length)
+        || (span.offset() + span.len() > self.offset && span.offset() + span.len() <= self.offset + self.length)
     }
 
     // A "flyby" is a multi-line span that technically covers this line, but


### PR DESCRIPTION
This changes the span_applies calculation to only count spans where the end of the span is considered part of it if the underline spills into it. I believe this happens if, say, the span.offset() is 10 and span.len() is 2, then we want to count offsets 10 and 11 as part of the span and those would spill, but not 12 as it's the "one past the end" where we know when to stop underlining.