### PR TITLE
docs: fix set_reporter to set_hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ miette::set_hook(Box::new(|_| {
 # .unwrap()
 ```
 
-See the docs for [MietteHandlerOptions] for more details on what you can customize!
+See the docs for [MietteHandlerOpts] for more details on what you can customize!
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ fn this_fails() -> Result<()> {
 Now to get everything printed nicely, just return a Result<()>
 and you're all set!
 
-Note: You can swap out the default reporter for a custom one using `miette::set_reporter()`
+Note: You can swap out the default reporter for a custom one using `miette::set_hook()`
 */
 fn pretend_this_is_main() -> Result<()> {
     // kaboom~


### PR DESCRIPTION
It seems it's a deprecated method