### PR TITLE
Add replace tabs with spaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ miette::set_hook(Box::new(|_| {
         .terminal_links(true)
         .unicode(false)
         .context_lines(3)
+        .with_tab_width(4)
         .build())
 }))
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ miette::set_hook(Box::new(|_| {
         .terminal_links(true)
         .unicode(false)
         .context_lines(3)
-        .with_tab_width(4)
+        .tab_width(4)
         .build())
 }))
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -39,6 +39,7 @@ pub struct MietteHandlerOpts {
     pub(crate) unicode: Option<bool>,
     pub(crate) footer: Option<String>,
     pub(crate) context_lines: Option<usize>,
+    pub(crate) tab_width: Option<usize>,
 }
 
 impl MietteHandlerOpts {
@@ -119,6 +120,12 @@ impl MietteHandlerOpts {
         self
     }
 
+    /// Set the displayed tab width in spaces.
+    pub fn tab_width(mut self, width: usize) -> Self {
+        self.tab_width = Some(width);
+        self
+    }
+
     /// Builds a [MietteHandler] from this builder.
     pub fn build(self) -> MietteHandler {
         let graphical = self.is_graphical();
@@ -166,6 +173,9 @@ impl MietteHandlerOpts {
             }
             if let Some(context_lines) = self.context_lines {
                 handler = handler.with_context_lines(context_lines);
+            }
+            if let Some(w) = self.tab_width {
+                handler = handler.tab_width(w);
             }
             MietteHandler {
                 inner: Box::new(handler),

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -565,6 +565,7 @@ impl GraphicalReportHandler {
             let hl_len = std::cmp::max(1, hl.len());
 
             let local_offset = if let Some(w) = self.tab_width {
+                // Only count tabs that affect the position of the highlighted line and ignore tabs past the span.
                 let tab_count = &line.text[..hl.offset() - line.offset].matches('\t').count();
                 let tabs_as_spaces = tab_count * w - tab_count;
                 hl.offset() - line.offset + tabs_as_spaces
@@ -605,6 +606,7 @@ impl GraphicalReportHandler {
             .iter()
             .map(|hl| {
                 let local_offset = if let Some(w) = self.tab_width {
+                    // Only count tabs that affect the position of the highlighted line and ignore tabs past the span.
                     let tab_count = &line.text[..hl.offset() - line.offset].matches('\t').count();
                     let tabs_as_spaces = tab_count * w - tab_count;
                     hl.offset() - line.offset + tabs_as_spaces

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -565,9 +565,7 @@ impl GraphicalReportHandler {
             let hl_len = std::cmp::max(1, hl.len());
 
             let local_offset = if let Some(w) = self.tab_width {
-                dbg!(&line.text[..hl.offset() - line.offset]);
                 let tab_count = &line.text[..hl.offset() - line.offset].matches('\t').count();
-                dbg!(tab_count);
                 let tabs_as_spaces = tab_count * w - tab_count;
                 hl.offset() - line.offset + tabs_as_spaces
             } else {
@@ -702,7 +700,6 @@ impl GraphicalReportHandler {
             }
 
             if column == 0 || iter.peek().is_none() {
-                dbg!("Line");
                 lines.push(Line {
                     line_number: line,
                     offset: line_offset,

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -54,8 +54,8 @@ impl GraphicalReportHandler {
         }
     }
 
-    /// Replace tabs with spaces.
-    pub fn with_tab_width(mut self, width: usize) -> Self {
+    /// Set the displayed tab width in spaces.
+    pub fn tab_width(mut self, width: usize) -> Self {
         self.tab_width = Some(width);
         self
     }

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -22,7 +22,7 @@ fn fmt_report(diag: Report) -> String {
     } else if let Ok(w) = std::env::var("REPLACE_TABS") {
         GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor())
             .with_width(80)
-            .with_tab_width(w.parse().expect("Invalid tab width."))
+            .tab_width(w.parse().expect("Invalid tab width."))
             .render_report(&mut out, diag.as_ref())
             .unwrap();
     } else {

--- a/tests/test_location.rs
+++ b/tests/test_location.rs
@@ -30,7 +30,6 @@ impl miette::ReportHandler for LocationHandler {
     }
 
     fn track_caller(&mut self, location: &'static Location<'static>) {
-        dbg!(location);
         self.actual = Some(location.file());
     }
 }


### PR DESCRIPTION
Closes #73 

Makes it possible to replace tabs with spaces. This is needed because highlight line renderers are not aware of displayed tab width and appear in wrong places if line contains tabs.