### PR TITLE
fix(colors): treat no-color mode as no-color instead of narratable

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -188,8 +188,8 @@ impl MietteHandlerOpts {
             !force_narrated
         } else if let Some(force_graphical) = self.force_graphical {
             force_graphical
-        } else if let Some(info) = supports_color::on(Stream::Stderr) {
-            info.has_basic
+        } else if let Ok(env) = std::env::var("NO_GRAPHICS") {
+            env == "0"
         } else {
             false
         }


### PR DESCRIPTION
This is a start, but I still want to add an environment variable to force "plaintext" mode. Maybe just "MIETTE_PLAINTEXT" or "PLAINTEXT_ERRORS"?

I'll sleep on it. Any opinions are welcome, tho.

Note that this PR is a breaking change, because some users possibly rely on this behavior to even be able to read their output.