### PR TITLE
docs: fix mentions of eyre and DiagnosticError

### DIFF
--- a/src/eyreish/into_diagnostic.rs
+++ b/src/eyreish/into_diagnostic.rs
@@ -10,7 +10,7 @@ struct DiagnosticError(Box<dyn std::error::Error + Send + Sync + 'static>);
 impl Diagnostic for DiagnosticError {}
 
 /**
-Convenience trait that adds a `.into_diagnostic()` method that converts a type to a `Result<T, DiagnosticError>`.
+Convenience trait that adds a `.into_diagnostic()` method that converts a type to a `Result<T, Report>`.
 */
 pub trait IntoDiagnostic<T, E> {
     /// Converts [Result]-like types that return regular errors into a

--- a/src/eyreish/mod.rs
+++ b/src/eyreish/mod.rs
@@ -347,7 +347,7 @@ pub type Result<T, E = Report> = core::result::Result<T, E>;
 /// After attaching a message of type `D` onto an error of type `E`, the resulting
 /// `miette::Error` may be downcast to `D` **or** to `E`.
 ///
-/// That is, in codebases that rely on downcasting, Eyre's wrap_err supports
+/// That is, in codebases that rely on downcasting, miette's wrap_err supports
 /// both of the following use cases:
 ///
 ///   - **Attaching messages whose type is insignificant onto errors whose type
@@ -355,7 +355,7 @@ pub type Result<T, E = Report> = core::result::Result<T, E>;
 ///
 ///     In other error libraries whose wrap_err is not designed this way, it can
 ///     be risky to introduce messages to existing code because new message might
-///     break existing working downcasts. In Eyre, any downcast that worked
+///     break existing working downcasts. In miette, any downcast that worked
 ///     before adding the message will continue to work after you add a message, so
 ///     you should freely wrap errors wherever it would be helpful.
 ///


### PR DESCRIPTION
Note: `DiagnosticError` is a private type, `Report` returned from
`into_diagnostic()` instead.