### PR TITLE
Fix bugs in JSON handler

### DIFF
--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -107,7 +107,13 @@ impl JSONReportHandler {
         }
         if let Some(relateds) = diagnostic.related() {
             write!(f, r#""related": ["#)?;
+            let mut add_comma = false;
             for related in relateds {
+                if add_comma {
+                    write!(f, ",")?;
+                } else {
+                    add_comma = true;
+                }
                 self.render_report(f, related)?;
             }
             write!(f, "]")?;

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -497,7 +497,7 @@ mod json_report_handler {
         println!("Error: {}", out);
         let expected: String = r#"
         {
-            "message": "wtf?!\\nit broke :(",
+            "message": "wtf?!\nit broke :(",
             "code": "oops::my::bad",
             "severity": "error",
             "help": "try doing it better next time?",

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -737,11 +737,18 @@ mod json_report_handler {
         let err = MyBad {
             src: NamedSource::new("bad_file.rs", src.clone()),
             highlight: (9, 4).into(),
-            related: vec![MyBad {
-                src: NamedSource::new("bad_file2.rs", src),
-                highlight: (0, 6).into(),
-                related: vec![],
-            }],
+            related: vec![
+                MyBad {
+                    src: NamedSource::new("bad_file2.rs", src.clone()),
+                    highlight: (0, 6).into(),
+                    related: vec![],
+                },
+                MyBad {
+                    src: NamedSource::new("bad_file3.rs", src),
+                    highlight: (0, 6).into(),
+                    related: vec![],
+                },
+            ],
         };
         let out = fmt_report(err.into());
         println!("Error: {}", out);
@@ -767,6 +774,22 @@ mod json_report_handler {
                 "severity": "error",
                 "help": "try doing it better next time?",
                 "filename": "bad_file2.rs",
+                "labels": [
+                    {
+                        "label": "this bit here",
+                        "span": {
+                            "offset": 0,
+                            "length": 6
+                        }
+                    }
+                ],
+                "related": []
+            },{
+                "message": "oops!",
+                "code": "oops::my::bad",
+                "severity": "error",
+                "help": "try doing it better next time?",
+                "filename": "bad_file3.rs",
                 "labels": [
                     {
                         "label": "this bit here",


### PR DESCRIPTION
Currently JSON handler can produce invalid JSON.

There are string escaping bugfixes:
1. Things like `\n` are not doubly-escaped any more
2. The backslash `\` itself in the source is escaped

And also `related` array was not comma-delimited.