### PR TITLE
fix(chain): correct `Chain` structure exported

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -8,6 +8,25 @@ use std::vec;
 
 use ChainState::*;
 
+/// Iterator of a chain of source errors.
+///
+/// This type is the iterator returned by [`Report::chain`].
+///
+/// # Example
+///
+/// ```
+/// use miette::Report;
+/// use std::io;
+///
+/// pub fn underlying_io_error_kind(error: &Report) -> Option<io::ErrorKind> {
+///     for cause in error.chain() {
+///         if let Some(io_error) = cause.downcast_ref::<io::Error>() {
+///             return Some(io_error.kind());
+///         }
+///     }
+///     None
+/// }
+/// ```
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct Chain<'a> {
@@ -25,7 +44,7 @@ pub(crate) enum ChainState<'a> {
 }
 
 impl<'a> Chain<'a> {
-    pub fn new(head: &'a (dyn StdError + 'static)) -> Self {
+    pub(crate) fn new(head: &'a (dyn StdError + 'static)) -> Self {
         Chain {
             state: ChainState::Linked { next: Some(head) },
         }

--- a/src/eyreish/mod.rs
+++ b/src/eyreish/mod.rs
@@ -191,31 +191,6 @@ pub trait ReportHandler: core::any::Any + Send + Sync {
     fn track_caller(&mut self, location: &'static std::panic::Location<'static>) {}
 }
 
-/// Iterator of a chain of source errors.
-///
-/// This type is the iterator returned by [`Report::chain`].
-///
-/// # Example
-///
-/// ```
-/// use miette::Report;
-/// use std::io;
-///
-/// pub fn underlying_io_error_kind(error: &Report) -> Option<io::ErrorKind> {
-///     for cause in error.chain() {
-///         if let Some(io_error) = cause.downcast_ref::<io::Error>() {
-///             return Some(io_error.kind());
-///         }
-///     }
-///     None
-/// }
-/// ```
-#[derive(Clone)]
-#[allow(missing_debug_implementations)]
-pub struct Chain<'a> {
-    state: crate::chain::ChainState<'a>,
-}
-
 /// type alias for `Result<T, Report>`
 ///
 /// This is a reasonable return type to use throughout your application but also for `fn main`; if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 pub use miette_derive::*;
 
-pub use chain::*;
 pub use error::*;
 pub use eyreish::*;
 #[cfg(feature = "fancy")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub use miette_derive::*;
 
+pub use chain::*;
 pub use error::*;
 pub use eyreish::*;
 #[cfg(feature = "fancy")]

--- a/tests/test_context.rs
+++ b/tests/test_context.rs
@@ -19,6 +19,7 @@ macro_rules! context_type {
         #[derive(Debug)]
         struct $name {
             message: &'static str,
+            #[allow(dead_code)]
             drop: DetectDrop,
         }
 


### PR DESCRIPTION
This fixes all current compiler and clippy warnings.

It looks like wrong `Chain` type was exported. This is technically could be seemed as a breaking change, but in reality should not break anyone since that type was not used and could not be created I think.