### PR TITLE
feat(Report): adds `.context()` method to the `Report`

### DIFF
--- a/src/eyreish/error.rs
+++ b/src/eyreish/error.rs
@@ -220,6 +220,14 @@ impl Report {
         unsafe { Report::construct(error, vtable, handler) }
     }
 
+    /// Compatibility re-export of wrap_err for interop with `anyhow`
+    pub fn context<D>(self, msg: D) -> Self
+    where
+        D: Display + Send + Sync + 'static,
+    {
+        self.wrap_err(msg)
+    }
+
     /// An iterator of the chain of source errors contained by this Report.
     ///
     /// This iterator will visit every error in the cause chain of this error
@@ -376,18 +384,6 @@ impl Report {
 
     /// Get a mutable reference to the Handler for this Report.
     pub fn handler_mut(&mut self) -> &mut dyn ReportHandler {
-        self.inner.handler.as_mut().unwrap().as_mut()
-    }
-
-    /// Get a reference to the Handler for this Report.
-    #[doc(hidden)]
-    pub fn context(&self) -> &dyn ReportHandler {
-        self.inner.handler.as_ref().unwrap().as_ref()
-    }
-
-    /// Get a mutable reference to the Handler for this Report.
-    #[doc(hidden)]
-    pub fn context_mut(&mut self) -> &mut dyn ReportHandler {
         self.inner.handler.as_mut().unwrap().as_mut()
     }
 }

--- a/tests/test_handler_access.rs
+++ b/tests/test_handler_access.rs
@@ -1,7 +1,7 @@
 #[test]
-fn test_context() {
+fn test_handler() {
     use miette::{miette, Report};
 
     let error: Report = miette!("oh no!");
-    let _ = error.context();
+    let _ = error.handler();
 }


### PR DESCRIPTION
Techically there was a hidden undocumented `context` method. But it was
just copied from the `eyre` and there is no evidence that it was used by
any user in miette (the method was an alias for `.handler()`).

Fixes #108