### PR TITLE
Add field variant of help

### DIFF
--- a/miette-derive/src/field_help.rs
+++ b/miette-derive/src/field_help.rs
@@ -1,0 +1,81 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+
+use crate::{
+    diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
+    forward::WhichFn,
+    utils::{display_pat_members, gen_all_variants_with},
+};
+
+pub struct FieldHelp {
+    help: syn::Member,
+}
+
+impl FieldHelp {
+    pub fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
+        match fields {
+            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
+            syn::Fields::Unnamed(unnamed) => {
+                Self::from_fields_vec(unnamed.unnamed.iter().collect())
+            }
+            syn::Fields::Unit => Ok(None),
+        }
+    }
+
+    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
+        for (i, field) in fields.iter().enumerate() {
+            for attr in &field.attrs {
+                if attr.path.is_ident("help") {
+                    let help = if let Some(ident) = field.ident.clone() {
+                        syn::Member::Named(ident)
+                    } else {
+                        syn::Member::Unnamed(syn::Index {
+                            index: i as u32,
+                            span: field.span(),
+                        })
+                    };
+                    return Ok(Some(Self { help }));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    pub(crate) fn gen_struct(&self, fields: &syn::Fields) -> Option<TokenStream> {
+        let (display_pat, _display_members) = display_pat_members(fields);
+        let src = &self.help;
+        Some(quote! {
+            #[allow(unused_variables)]
+            fn help<'a>(&'a self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + 'a>> {
+                let Self #display_pat = self;
+                std::option::Option::Some(std::boxed::Box::new(&self.#src))
+            }
+        })
+    }
+
+    pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {
+        gen_all_variants_with(
+            variants,
+            WhichFn::Help,
+            |ident, fields, DiagnosticConcreteArgs { field_help, .. }| {
+                let (display_pat, _display_members) = display_pat_members(fields);
+                field_help.as_ref().and_then(|help| {
+                    let field = match &help.help {
+                        syn::Member::Named(ident) => ident.clone(),
+                        syn::Member::Unnamed(syn::Index { index, .. }) => {
+                            format_ident!("_{}", index)
+                        }
+                    };
+                    let variant_name = ident.clone();
+                    match &fields {
+                        syn::Fields::Unit => None,
+                        _ => Some(quote! {
+                            Self::#variant_name #display_pat => std::option::Option::Some(Box::new(#field.to_string().into_boxed_str())),
+                        }),
+                    }
+                })
+            },
+        )
+    }
+}

--- a/miette-derive/src/lib.rs
+++ b/miette-derive/src/lib.rs
@@ -6,6 +6,7 @@ use diagnostic::Diagnostic;
 mod code;
 mod diagnostic;
 mod diagnostic_arg;
+mod field_help;
 mod fmt;
 mod forward;
 mod help;
@@ -16,7 +17,7 @@ mod source_code;
 mod url;
 mod utils;
 
-#[proc_macro_derive(Diagnostic, attributes(diagnostic, source_code, label, related))]
+#[proc_macro_derive(Diagnostic, attributes(diagnostic, source_code, label, related, help))]
 pub fn derive_diagnostic(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let cmd = match Diagnostic::from_derive_input(input) {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -288,6 +288,56 @@ fn test_snippet_enum() {
 }
 
 #[test]
+fn field_help() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("welp")]
+    #[diagnostic(code(foo::bar::baz))]
+    struct FooStruct {
+        #[help]
+        help: &'static str,
+    }
+
+    assert_eq!(
+        "try doing it better".to_string(),
+        FooStruct {
+            help: "try doing it better"
+        }
+        .help()
+        .unwrap()
+        .to_string()
+    );
+
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("welp")]
+    enum FooEnum {
+        #[diagnostic(code(foo::x))]
+        X(#[help] String),
+        #[diagnostic(code(foo::y))]
+        Y {
+            #[help]
+            help: String,
+        },
+    }
+
+    assert_eq!(
+        "try doing it better".to_string(),
+        FooEnum::X("try doing it better".to_string())
+            .help()
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "try doing it better".to_string(),
+        FooEnum::Y {
+            help: "try doing it better".to_string()
+        }
+        .help()
+        .unwrap()
+        .to_string()
+    );
+}
+
+#[test]
 fn url_basic() {
     #[derive(Debug, Diagnostic, Error)]
     #[error("welp")]


### PR DESCRIPTION
Fixes #112.  Looks like:

```rust
#[derive(Debug, Diagnostic, Error)]
#[error("welp")]
struct FooStruct {
    #[help]
    help: &'static str,
}

#[derive(Debug, Diagnostic, Error)]
#[error("welp")]
enum FooEnum {
    X(#[help] String),

    Y {
        #[help]
        help: String,
    },
}
```

I'd like some help!

- [x] General "is this the right direction"
- [ ] Forwarding-with-overriden-help tests are failing, and I'm not sure how to approach it. I'll keep looking, but would appreciate any pointers
- [x] When both derive-arg and field help is provided, the procmacro panics because this is detected at codegen time. Is this fine? Is there a better way to handle it?