### PR TITLE
More ergonomic source code handling

### DIFF
--- a/src/eyreish/error.rs
+++ b/src/eyreish/error.rs
@@ -7,7 +7,8 @@ use std::error::Error as StdError;
 use super::Report;
 use super::ReportHandler;
 use crate::chain::Chain;
-use crate::Diagnostic;
+use crate::eyreish::wrapper::WithSourceCode;
+use crate::{Diagnostic, SourceCode};
 use core::ops::{Deref, DerefMut};
 
 impl Report {
@@ -385,6 +386,15 @@ impl Report {
     /// Get a mutable reference to the Handler for this Report.
     pub fn handler_mut(&mut self) -> &mut dyn ReportHandler {
         self.inner.handler.as_mut().unwrap().as_mut()
+    }
+
+    /// Provide source code for this error
+    pub fn with_source_code(self, source_code: impl SourceCode + Send + Sync + 'static) -> Report {
+        WithSourceCode {
+            source_code,
+            error: self,
+        }
+        .into()
     }
 }
 

--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Debug, Display};
 
 use std::error::Error as StdError;
 
-use crate::{Diagnostic, LabeledSpan};
+use crate::{Diagnostic, LabeledSpan, Report, SourceCode};
 
 use crate as miette;
 
@@ -117,3 +117,92 @@ impl Display for BoxedError {
 }
 
 impl StdError for BoxedError {}
+
+pub(crate) struct WithSourceCode<E, C> {
+    pub(crate) error: E,
+    pub(crate) source_code: C,
+}
+
+impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.error.code()
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        self.error.severity()
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.error.help()
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.error.url()
+    }
+
+    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+        self.error.labels()
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source_code)
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        self.error.related()
+    }
+}
+
+impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.error.code()
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        self.error.severity()
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.error.help()
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.error.url()
+    }
+
+    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+        self.error.labels()
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source_code)
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        self.error.related()
+    }
+}
+
+impl<E: Debug, C> Debug for WithSourceCode<E, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.error, f)
+    }
+}
+
+impl<E: Display, C> Display for WithSourceCode<E, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.error, f)
+    }
+}
+
+impl<E: StdError, C> StdError for WithSourceCode<E, C> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.error.source()
+    }
+}
+
+impl<C> StdError for WithSourceCode<Report, C> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.error.source()
+    }
+}


### PR DESCRIPTION
Fixes #64 and #99

@zkat, I'm not sure what you mean by `source_code()` and `with_source_code()` code in #64. Since the report object is already an error it doesn't make much sense to put a lambda there. And since `source_code()` might be confused with `Diagnostic::source_code` I think `with_` works better.

The internal `WithSourceCode` wrapper is designed in a way that would allow adding `with_source_code` on error or even `WrapErr`. But I'm not sure these are needed, so did not include in the PR.
