### PR TITLE
feat(derive): allow `Report` in `related`

### DIFF
--- a/miette-derive/src/related.rs
+++ b/miette-derive/src/related.rs
@@ -69,7 +69,10 @@ impl Related {
         let rel = &self.0;
         Some(quote! {
             fn related<'a>(&'a self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
-                std::option::Option::Some(std::boxed::Box::new(self.#rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x })))
+                use ::core::borrow::Borrow;
+                std::option::Option::Some(std::boxed::Box::new(
+                        self.#rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x.borrow() })
+                ))
             }
         })
     }

--- a/src/eyreish/error.rs
+++ b/src/eyreish/error.rs
@@ -727,3 +727,9 @@ impl AsRef<dyn Diagnostic> for Report {
         &**self
     }
 }
+
+impl std::borrow::Borrow<dyn Diagnostic> for Report {
+    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+        self.as_ref()
+    }
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,4 +1,4 @@
-use miette::{Diagnostic, Severity, SourceSpan};
+use miette::{Diagnostic, Report, Severity, SourceSpan};
 use thiserror::Error;
 
 #[test]
@@ -30,6 +30,17 @@ fn related() {
     #[derive(Error, Debug, Diagnostic)]
     #[error("welp2")]
     struct Baz;
+}
+
+#[test]
+fn related_report() {
+    #[derive(Error, Debug, Diagnostic)]
+    #[error("welp")]
+    #[diagnostic(code(foo::bar::baz))]
+    struct Foo {
+        #[related]
+        related: Vec<Report>,
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #119

I'm not sure if using `borrow()` should be thought of as a great way to handle the issue or it's a hack.

The alternative would be to make some private trait that we have to expose using `docs(hidden)` for derive to use. But this may also make error reporting confusing (i.e. failing with trait name that can't be found anywhere in the docs).

I think `Borrow` is safe to implement for the `Report`. I had a tiny concern that it make prohibit using error types with (non-static) lifetimes in `related`. But I think it's *not the case*. Although, I could not test that as code-gen for nonstatic lifetimes in `related` is untested and broken for now.