### PR TITLE
fix: set correct field in MietteHandlerOpts::ansi_colors

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -93,7 +93,7 @@ impl MietteHandlerOpts {
 
     /// If true, ANSI colors will be used during graphical rendering.
     pub fn ansi_colors(mut self, color: bool) -> Self {
-        self.rgb_colors = Some(color);
+        self.ansi_colors = Some(color);
         self
     }
     /// If true, graphical rendering will be used regardless of terminal


### PR DESCRIPTION
Thanks for miette! We've been having a great time using it in
cargo-nextest to print out nicely-formatted errors.

I noticed a bug while testing out miette -- the `ansi_colors` method
does not set ANSI colors properly.

By the way, I do not believe miette should use RGB colors at all --
default colors in applications must be restricted to 12 ANSI colors. See
https://rust-cli-recommendations.sunshowers.io/colors.html#color-palettes
for why. I'm happy to disable RGB colors in all the applications I
maintain, but doing so globally is something for upstream to consider.