### PR TITLE
feat: make SourceSpan implement Copy

### DIFF
--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -47,7 +47,7 @@ impl SourceCode for NamedSource {
         Ok(Box::new(MietteSpanContents::new_named(
             self.name.clone(),
             contents.data(),
-            contents.span().clone(),
+            *contents.span(),
             contents.line(),
             contents.column(),
             contents.line_count(),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -345,7 +345,7 @@ impl<'a> SpanContents<'a> for MietteSpanContents<'a> {
 /**
 Span within a [`SourceCode`] with an associated message.
 */
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct SourceSpan {
     /// The start of the span.
     offset: SourceOffset,


### PR DESCRIPTION
SourceSpan is just a pair of usizes, so it's cheap to copy.