### PR TITLE
Render inner diagnostics

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -261,6 +261,7 @@ impl GraphicalReportHandler {
                         // Don't print footer for inner errors
                         let mut inner_renderer = self.clone();
                         inner_renderer.footer = None;
+                        inner_renderer.with_cause_chain = false;
                         inner_renderer.render_report(&mut inner, diag)?;
 
                         writeln!(f, "{}", textwrap::fill(&inner, opts))?;

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -151,7 +151,6 @@ impl GraphicalReportHandler {
         diagnostic: &(dyn Diagnostic),
     ) -> fmt::Result {
         self.render_header(f, diagnostic)?;
-        writeln!(f)?;
         self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();
         self.render_snippets(f, diagnostic, src)?;
@@ -190,6 +189,7 @@ impl GraphicalReportHandler {
             );
             write!(header, "{}", link)?;
             writeln!(f, "{}", header)?;
+            writeln!(f)?;
         } else if let Some(code) = diagnostic.code() {
             write!(header, "{}", code.style(severity_style),)?;
             if self.links == LinkStyle::Text && diagnostic.url().is_some() {
@@ -197,6 +197,7 @@ impl GraphicalReportHandler {
                 write!(header, " ({})", url.style(self.theme.styles.link))?;
             }
             writeln!(f, "{}", header)?;
+            writeln!(f)?;
         }
         Ok(())
     }
@@ -301,7 +302,6 @@ impl GraphicalReportHandler {
                     Some(Severity::Advice) => write!(f, "Advice: ")?,
                 };
                 self.render_header(f, rel)?;
-                writeln!(f)?;
                 self.render_causes(f, rel)?;
                 let src = rel.source_code().or(parent_src);
                 self.render_snippets(f, rel, src)?;

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -85,8 +85,7 @@ fn single_line_highlight_span_full_line() {
     let out = fmt_report(err.into());
     println!("Error: {}", out);
 
-    let expected = r#"
-  × oops!
+    let expected = r#"  × oops!
    ╭─[issue:1:1]
  1 │ source
  2 │ text
@@ -1201,8 +1200,7 @@ fn zero_length_eol_span() {
     let out = fmt_report(err.into());
     println!("Error: {}", out);
 
-    let expected = r#"
-  × oops!
+    let expected = r#"  × oops!
    ╭─[issue:1:1]
  1 │ this is the first line
  2 │ this is the second line


### PR DESCRIPTION
Previously `#[diagnostic_source]` did not correctly render the inner diagnostic. This PR fixes that.

There's a change here that can be considered controversial:

- Only print newlines when there is an actual header (in ad9d0378ddd6dd4a6b9e650dd6aa62116da65910)

I am fine with removing it, but then the nested diagnostic source will be offset by one line and appear floating when it does not print a header.


PS: This PR also includes things from #169. I will rebase once that is merged (hopefully?)