### PR TITLE
Group related diagnostics visually

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ indenter = "0.3.0"
 rustversion = "1.0"
 trybuild = { version = "1.0.19", features = ["diff"] }
 syn = { version = "1.0", features = ["full"] }
+pretty_assertions = "1.2.1"
 
 [features]
 default = []

--- a/miette-derive/src/diagnostic_source.rs
+++ b/miette-derive/src/diagnostic_source.rs
@@ -59,7 +59,8 @@ impl DiagnosticSource {
                     };
                     quote! {
                         Self::#ident #display_pat => {
-                            std::option::Option::Some(#rel.as_ref())
+                            use std::borrow::Borrow;
+                            std::option::Option::Some(#rel.borrow())
                         }
                     }
                 })
@@ -71,7 +72,8 @@ impl DiagnosticSource {
         let rel = &self.0;
         Some(quote! {
             fn diagnostic_source<'a>(&'a self) -> std::option::Option<&'a dyn miette::Diagnostic> {
-                std::option::Option::Some(&self.#rel)
+                use std::borrow::Borrow;
+                std::option::Option::Some(self.#rel.borrow())
             }
         })
     }

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -133,7 +133,6 @@ impl GraphicalReportHandler {
         diagnostic: &(dyn Diagnostic),
     ) -> fmt::Result {
         self.render_header(f, diagnostic)?;
-        writeln!(f)?;
         self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();
         self.render_snippets(f, diagnostic, src)?;
@@ -172,6 +171,7 @@ impl GraphicalReportHandler {
             );
             write!(header, "{}", link)?;
             writeln!(f, "{}", header)?;
+            writeln!(f)?;
         } else if let Some(code) = diagnostic.code() {
             write!(header, "{}", code.style(severity_style),)?;
             if self.links == LinkStyle::Text && diagnostic.url().is_some() {
@@ -179,6 +179,7 @@ impl GraphicalReportHandler {
                 write!(header, " ({})", url.style(self.theme.styles.link))?;
             }
             writeln!(f, "{}", header)?;
+            writeln!(f)?;
         }
         Ok(())
     }

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Write};
 
 use owo_colors::{OwoColorize, Style};
 
-use crate::diagnostic_chain::DiagnosticChain;
+use crate::diagnostic_chain::{DiagnosticChain, ErrorKind};
 use crate::handlers::theme::*;
 use crate::protocol::{Diagnostic, Severity};
 use crate::{LabeledSpan, MietteError, ReportHandler, SourceCode, SourceSpan, SpanContents};
@@ -231,7 +231,21 @@ impl GraphicalReportHandler {
                 let opts = textwrap::Options::new(width)
                     .initial_indent(&initial_indent)
                     .subsequent_indent(&rest_indent);
-                writeln!(f, "{}", textwrap::fill(&error.to_string(), opts))?;
+                match error {
+                    ErrorKind::Diagnostic(diag) => {
+                        let mut inner = String::new();
+
+                        // Don't print footer for inner errors
+                        let mut inner_renderer = self.clone();
+                        inner_renderer.footer = None;
+                        inner_renderer.render_report(&mut inner, diag)?;
+
+                        writeln!(f, "{}", textwrap::fill(&inner, opts))?;
+                    }
+                    ErrorKind::StdError(err) => {
+                        writeln!(f, "{}", textwrap::fill(&err.to_string(), opts))?;
+                    }
+                }
             }
         }
 

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -806,6 +806,7 @@ fn related() -> Result<(), MietteError> {
 
 Error: oops::my::bad
 
+
   × oops!
    ╭─[bad_file.rs:1:1]
  1 │ source
@@ -868,6 +869,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
 
 Error: oops::my::bad
 
+
   × oops!
    ╭─[bad_file.rs:1:1]
  1 │ source
@@ -900,8 +902,7 @@ fn zero_length_eol_span() {
     let out = fmt_report(err.into());
     println!("Error: {}", out);
 
-    let expected = r#"
-  × oops!
+    let expected = r#"  × oops!
    ╭─[issue:1:1]
  1 │ this is the first line
  2 │ this is the second line

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -5,6 +5,7 @@ use miette::{
     NarratableReportHandler, Report, SourceSpan,
 };
 use thiserror::Error;
+use pretty_assertions::assert_eq;
 
 fn fmt_report(diag: Report) -> String {
     let mut out = String::new();
@@ -784,11 +785,22 @@ fn related() -> Result<(), MietteError> {
     let err = MyBad {
         src: NamedSource::new("bad_file.rs", src.clone()),
         highlight: (9, 4).into(),
-        related: vec![MyBad {
-            src: NamedSource::new("bad_file.rs", src),
-            highlight: (0, 6).into(),
-            related: vec![],
-        }],
+        related: vec![
+            MyBad {
+                src: NamedSource::new("bad_file.rs", src.clone()),
+                highlight: (0, 6).into(),
+                related: vec![MyBad {
+                    src: NamedSource::new("bad_file.rs", src.clone()),
+                    highlight: (0, 6).into(),
+                    related: vec![],
+                }],
+            },
+            MyBad {
+                src: NamedSource::new("bad_file.rs", src.clone()),
+                highlight: (0, 6).into(),
+                related: vec![],
+            },
+        ],
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
@@ -803,19 +815,46 @@ fn related() -> Result<(), MietteError> {
  3 │     here
    ╰────
   help: try doing it better next time?
-
-Error: oops::my::bad
-
-
-  × oops!
-   ╭─[bad_file.rs:1:1]
- 1 │ source
-   · ───┬──
-   ·    ╰── this bit here
- 2 │   text
-   ╰────
-  help: try doing it better next time?
-
+╭─There were 2 related diagnostics:
+├─ 1.Error: oops::my::bad
+│ 
+│ 
+│   × oops!
+│    ╭─[bad_file.rs:1:1]
+│  1 │ source
+│    · ───┬──
+│    ·    ╰── this bit here
+│  2 │   text
+│    ╰────
+│   help: try doing it better next time?
+│ ╭─There were 1 related diagnostics:
+│ ├─ 1.Error: oops::my::bad
+│ │
+│ │
+│ │   × oops!
+│ │    ╭─[bad_file.rs:1:1]
+│ │  1 │ source
+│ │    · ───┬──
+│ │    ·    ╰── this bit here
+│ │  2 │   text
+│ │    ╰────
+│ │   help: try doing it better next time?
+│ │ ├─There were 0 related diagnostics:
+│ │
+│ 
+├─ 2.Error: oops::my::bad
+│ 
+│ 
+│   × oops!
+│    ╭─[bad_file.rs:1:1]
+│  1 │ source
+│    · ───┬──
+│    ·    ╰── this bit here
+│  2 │   text
+│    ╰────
+│   help: try doing it better next time?
+│ ├─There were 0 related diagnostics:
+│ 
 "#
     .trim_start()
     .to_string();
@@ -866,17 +905,18 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
  3 │     here
    ╰────
   help: try doing it better next time?
-
-Error: oops::my::bad
-
-
-  × oops!
-   ╭─[bad_file.rs:1:1]
- 1 │ source
-   · ───┬──
-   ·    ╰── this bit here
- 2 │   text
-   ╰────
+╭─There were 1 related diagnostics:
+├─ 1.Error: oops::my::bad
+│ 
+│ 
+│   × oops!
+│    ╭─[bad_file.rs:1:1]
+│  1 │ source
+│    · ───┬──
+│    ·    ╰── this bit here
+│  2 │   text
+│    ╰────
+│ 
 "#
     .trim_start()
     .to_string();

--- a/tests/test_diagnostic_source_macro.rs
+++ b/tests/test_diagnostic_source_macro.rs
@@ -6,15 +6,56 @@ struct AnErr;
 
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
 #[error("TestError")]
-struct TestError {
+struct TestStructError {
     #[diagnostic_source]
     asdf_inner_foo: AnErr,
 }
 
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("TestError")]
+enum TestEnumError {
+    Without,
+    WithTuple(#[diagnostic_source] AnErr),
+    WithStruct {
+        #[diagnostic_source]
+        inner: AnErr,
+    },
+}
+
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("TestError")]
+struct TestTupleError(#[diagnostic_source] AnErr);
+
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("TestError")]
+struct TestBoxedError(#[diagnostic_source] Box<dyn Diagnostic>);
+
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("TestError")]
+struct TestArcedError(#[diagnostic_source] std::sync::Arc<dyn Diagnostic>);
+
 #[test]
 fn test_diagnostic_source() {
-    let error = TestError {
+    let error = TestStructError {
         asdf_inner_foo: AnErr,
     };
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestEnumError::Without;
+    assert!(error.diagnostic_source().is_none());
+
+    let error = TestEnumError::WithTuple(AnErr);
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestEnumError::WithStruct { inner: AnErr };
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestTupleError(AnErr);
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestBoxedError(Box::new(AnErr));
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestArcedError(std::sync::Arc::new(AnErr));
     assert!(error.diagnostic_source().is_some());
 }


### PR DESCRIPTION
I understand that this can be a controversial change, so this is very much a suggestion. The idea would be to group related errors so that end-user understands what exactly caused the problems they've encountered.

An example from the tests:
```
Error: oops::my::bad

  × oops!
   ╭─[bad_file.rs:1:1]
 1 │ source
 2 │   text
   ·   ──┬─
   ·     ╰── this bit here
 3 │     here
   ╰────
  help: try doing it better next time?
╭─There were 2 related diagnostics:
├─ 1.Error: oops::my::bad
│
│
│   × oops!
│    ╭─[bad_file.rs:1:1]
│  1 │ source
│    · ───┬──
│    ·    ╰── this bit here
│  2 │   text
│    ╰────
│   help: try doing it better next time?
│ ╭─There were 1 related diagnostics:
│ ├─ 1.Error: oops::my::bad
│ │
│ │
│ │   × oops!
│ │    ╭─[bad_file.rs:1:1]
│ │  1 │ source
│ │    · ───┬──
│ │    ·    ╰── this bit here
│ │  2 │   text
│ │    ╰────
│ │   help: try doing it better next time?
│ │ ├─There were 0 related diagnostics:
│ │
│
├─ 2.Error: oops::my::bad
│
│
│   × oops!
│    ╭─[bad_file.rs:1:1]
│  1 │ source
│    · ───┬──
│    ·    ╰── this bit here
│  2 │   text
│    ╰────
│   help: try doing it better next time?
│ ├─There were 0 related diagnostics:
│
```