### PR TITLE
Don't escape single-quotes, that's not valid json

### DIFF
--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -30,7 +30,6 @@ impl fmt::Display for Escape<'_> {
             let escape = match c {
                 '\\' => Some(r"\\"),
                 '"' => Some(r#"\""#),
-                '\'' => Some(r"\'"),
                 '\r' => Some(r"\r"),
                 '\n' => Some(r"\n"),
                 '\t' => Some(r"\t"),


### PR DESCRIPTION
See for instance how this json parser gets mad:

```json
{
  "hello": "\\ \" \n \r \t \b \f"
  "oops": "this is evil \' oh no!"
}
```