### PR TITLE
Implement SourceCode for Arc<str> (and similar types)

### DIFF
--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -158,7 +158,7 @@ impl SourceCode for String {
     }
 }
 
-impl<T: SourceCode> SourceCode for Arc<T> {
+impl<T: ?Sized + SourceCode> SourceCode for Arc<T> {
     fn read_span<'a>(
         &'a self,
         span: &SourceSpan,


### PR DESCRIPTION
Adding the ?Sized bound allows use of Arc<str> as a source code type