### PR TITLE
Doesn't compile with supports-color 1.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,21 @@ jobs:
       - name: Run tests
         run: cargo test --all --verbose --features fancy
 
+  minimal_versions:
+    name: Minimal versions check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: Run minimal version build
+        run: cargo build -Z minimal-versions --all-features
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ owo-colors = { version = "3.0.0", optional = true }
 atty = { version = "0.2.14", optional = true }
 textwrap = { version = "0.15.0", optional = true }
 supports-hyperlinks = { version = "1.1.0", optional = true }
-supports-color = { version = "1.0.4", optional = true }
+supports-color = { version = "1.1.1", optional = true }
 supports-unicode = { version = "1.0.0", optional = true }
 backtrace = { version = "0.3.61", optional = true }
 terminal_size = { version = "0.1.17", optional = true }


### PR DESCRIPTION
https://github.com/palfrey/miette/runs/7059873509?check_suite_focus=true demonstrates the bug.

This PR:
* Adds a build with the minimal supplied versions from the Cargo.toml (which needs nightly for the -Z flag) to check for the problem
* Upgrades supports-color to 1.1.1 which is the first version that compiles successfully