### PR TITLE
Allow miette users to opt-out of the rendering of the cause chain

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -56,7 +56,7 @@ pub struct MietteHandlerOpts {
     pub(crate) footer: Option<String>,
     pub(crate) context_lines: Option<usize>,
     pub(crate) tab_width: Option<usize>,
-    pub(crate) with_cause_chain: Option<bool>
+    pub(crate) with_cause_chain: Option<bool>,
 }
 
 impl MietteHandlerOpts {
@@ -87,7 +87,7 @@ impl MietteHandlerOpts {
         self.width = Some(width);
         self
     }
-    
+
     /// Include the cause chain of the top-level error in the report.
     pub fn with_cause_chain(mut self) -> Self {
         self.with_cause_chain = Some(true);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -56,6 +56,7 @@ pub struct MietteHandlerOpts {
     pub(crate) footer: Option<String>,
     pub(crate) context_lines: Option<usize>,
     pub(crate) tab_width: Option<usize>,
+    pub(crate) with_cause_chain: Option<bool>
 }
 
 impl MietteHandlerOpts {
@@ -84,6 +85,18 @@ impl MietteHandlerOpts {
     /// Sets the width to wrap the report at. Defaults to 80.
     pub fn width(mut self, width: usize) -> Self {
         self.width = Some(width);
+        self
+    }
+    
+    /// Include the cause chain of the top-level error in the report.
+    pub fn with_cause_chain(mut self) -> Self {
+        self.with_cause_chain = Some(true);
+        self
+    }
+
+    /// Do not include the cause chain of the top-level error in the report.
+    pub fn without_cause_chain(mut self) -> Self {
+        self.with_cause_chain = Some(false);
         self
     }
 
@@ -165,6 +178,13 @@ impl MietteHandlerOpts {
             if let Some(context_lines) = self.context_lines {
                 handler = handler.with_context_lines(context_lines);
             }
+            if let Some(with_cause_chain) = self.with_cause_chain {
+                if with_cause_chain {
+                    handler = handler.with_cause_chain();
+                } else {
+                    handler = handler.without_cause_chain();
+                }
+            }
             MietteHandler {
                 inner: Box::new(handler),
             }
@@ -197,6 +217,13 @@ impl MietteHandlerOpts {
                 .with_width(width)
                 .with_links(linkify)
                 .with_theme(theme);
+            if let Some(with_cause_chain) = self.with_cause_chain {
+                if with_cause_chain {
+                    handler = handler.with_cause_chain();
+                } else {
+                    handler = handler.without_cause_chain();
+                }
+            }
             if let Some(footer) = self.footer {
                 handler = handler.with_footer(footer);
             }

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -149,9 +149,7 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         self.render_header(f, diagnostic)?;
         writeln!(f)?;
-        if self.with_cause_chain {
-            self.render_causes(f, diagnostic)?;
-        }
+        self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();
         self.render_snippets(f, diagnostic, src)?;
         self.render_footer(f, diagnostic)?;
@@ -216,6 +214,10 @@ impl GraphicalReportHandler {
 
         writeln!(f, "{}", textwrap::fill(&diagnostic.to_string(), opts))?;
 
+        if !self.with_cause_chain {
+            return Ok(())
+        }
+        
         if let Some(mut cause_iter) = diagnostic
             .diagnostic_source()
             .map(DiagnosticChain::from_diagnostic)

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -28,6 +28,7 @@ pub struct GraphicalReportHandler {
     pub(crate) footer: Option<String>,
     pub(crate) context_lines: usize,
     pub(crate) tab_width: Option<usize>,
+    pub(crate) with_cause_chain: bool
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +49,7 @@ impl GraphicalReportHandler {
             footer: None,
             context_lines: 1,
             tab_width: None,
+            with_cause_chain: true 
         }
     }
 
@@ -60,6 +62,7 @@ impl GraphicalReportHandler {
             footer: None,
             context_lines: 1,
             tab_width: None,
+            with_cause_chain: true 
         }
     }
 
@@ -76,6 +79,18 @@ impl GraphicalReportHandler {
         } else {
             LinkStyle::Text
         };
+        self
+    }
+    
+    /// Include the cause chain of the top-level error in the graphical output, if available.
+    pub fn with_cause_chain(mut self) -> Self {
+        self.with_cause_chain = true;
+        self
+    }
+    
+    /// Do not include the cause chain of the top-level error in the graphical output.
+    pub fn without_cause_chain(mut self) -> Self {
+        self.with_cause_chain = false;
         self
     }
 
@@ -134,7 +149,9 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         self.render_header(f, diagnostic)?;
         writeln!(f)?;
-        self.render_causes(f, diagnostic)?;
+        if self.with_cause_chain {
+            self.render_causes(f, diagnostic)?;
+        }
         let src = diagnostic.source_code();
         self.render_snippets(f, diagnostic, src)?;
         self.render_footer(f, diagnostic)?;

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -28,7 +28,7 @@ pub struct GraphicalReportHandler {
     pub(crate) footer: Option<String>,
     pub(crate) context_lines: usize,
     pub(crate) tab_width: Option<usize>,
-    pub(crate) with_cause_chain: bool
+    pub(crate) with_cause_chain: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,7 +49,7 @@ impl GraphicalReportHandler {
             footer: None,
             context_lines: 1,
             tab_width: None,
-            with_cause_chain: true 
+            with_cause_chain: true,
         }
     }
 
@@ -62,7 +62,7 @@ impl GraphicalReportHandler {
             footer: None,
             context_lines: 1,
             tab_width: None,
-            with_cause_chain: true 
+            with_cause_chain: true,
         }
     }
 
@@ -81,14 +81,16 @@ impl GraphicalReportHandler {
         };
         self
     }
-    
-    /// Include the cause chain of the top-level error in the graphical output, if available.
+
+    /// Include the cause chain of the top-level error in the graphical output,
+    /// if available.
     pub fn with_cause_chain(mut self) -> Self {
         self.with_cause_chain = true;
         self
     }
-    
-    /// Do not include the cause chain of the top-level error in the graphical output.
+
+    /// Do not include the cause chain of the top-level error in the graphical
+    /// output.
     pub fn without_cause_chain(mut self) -> Self {
         self.with_cause_chain = false;
         self
@@ -215,9 +217,9 @@ impl GraphicalReportHandler {
         writeln!(f, "{}", textwrap::fill(&diagnostic.to_string(), opts))?;
 
         if !self.with_cause_chain {
-            return Ok(())
+            return Ok(());
         }
-        
+
         if let Some(mut cause_iter) = diagnostic
             .diagnostic_source()
             .map(DiagnosticChain::from_diagnostic)

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -14,6 +14,7 @@ non-graphical environments, such as non-TTY output.
 #[derive(Debug, Clone)]
 pub struct NarratableReportHandler {
     context_lines: usize,
+    with_cause_chain: bool,
     footer: Option<String>,
 }
 
@@ -24,7 +25,20 @@ impl NarratableReportHandler {
         Self {
             footer: None,
             context_lines: 1,
+            with_cause_chain: true
         }
+    }
+    
+    /// Include the cause chain of the top-level error in the report, if available.
+    pub fn with_cause_chain(mut self) -> Self {
+        self.with_cause_chain = true;
+        self
+    }
+
+    /// Do not include the cause chain of the top-level error in the report.
+    pub fn without_cause_chain(mut self) -> Self {
+        self.with_cause_chain = false;
+        self
     }
 
     /// Set the footer to be displayed at the end of the report.
@@ -57,7 +71,9 @@ impl NarratableReportHandler {
         diagnostic: &(dyn Diagnostic),
     ) -> fmt::Result {
         self.render_header(f, diagnostic)?;
-        self.render_causes(f, diagnostic)?;
+        if self.with_cause_chain {
+            self.render_causes(f, diagnostic)?;
+        }
         let src = diagnostic.source_code();
         self.render_snippets(f, diagnostic, src)?;
         self.render_footer(f, diagnostic)?;

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -25,11 +25,12 @@ impl NarratableReportHandler {
         Self {
             footer: None,
             context_lines: 1,
-            with_cause_chain: true
+            with_cause_chain: true,
         }
     }
-    
-    /// Include the cause chain of the top-level error in the report, if available.
+
+    /// Include the cause chain of the top-level error in the report, if
+    /// available.
     pub fn with_cause_chain(mut self) -> Self {
         self.with_cause_chain = true;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,15 +582,14 @@
 //! `miette` was not developed in a void. It owes enormous credit to various
 //! other projects and their authors:
 //!
-//! - [`anyhow`](http://crates.io/crates/anyhow) and
-//!   [`color-eyre`](https://crates.io/crates/color-eyre): these two
-//!   enormously influential error handling libraries have pushed forward the
-//!   experience of application-level error handling and error reporting.
-//!   `miette`'s `Report` type is an attempt at a very very rough version of
-//!   their `Report` types.
-//! - [`thiserror`](https://crates.io/crates/thiserror) for setting the
-//!   standard for library-level error definitions, and for being the
-//!   inspiration behind `miette`'s derive macro.
+//! - [`anyhow`](http://crates.io/crates/anyhow) and [`color-eyre`](https://crates.io/crates/color-eyre):
+//!   these two enormously influential error handling libraries have pushed
+//!   forward the experience of application-level error handling and error
+//!   reporting. `miette`'s `Report` type is an attempt at a very very rough
+//!   version of their `Report` types.
+//! - [`thiserror`](https://crates.io/crates/thiserror) for setting the standard
+//!   for library-level error definitions, and for being the inspiration behind
+//!   `miette`'s derive macro.
 //! - `rustc` and [@estebank](https://github.com/estebank) for their
 //!   state-of-the-art work in compiler diagnostics.
 //! - [`ariadne`](https://crates.io/crates/ariadne) for pushing forward how


### PR DESCRIPTION
Related to #191 

The default behaviour remains to render the cause chain, but knobs are exposed to allow avoiding cause chain rendering.