### PR TITLE
docs: remove sentence about `cargo-edit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ the following features:
 
 ### Installing
 
-Using [`cargo-edit`](https://crates.io/crates/cargo-edit):
-
 ```sh
 $ cargo add miette
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,6 @@
 //!
 //! ## Installing
 //!
-//! Using [`cargo-edit`](https://crates.io/crates/cargo-edit):
-//!
 //! ```sh
 //! $ cargo add miette
 //! ```


### PR DESCRIPTION
Cargo has built-in since [v1.62](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-162-2022-06-30), so we don't need `cargo-edit`.