### PR TITLE
Fix graphical label alignment issues 

### DIFF
--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -82,7 +82,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
     let src = "source\n  👼🏼text\n    here".to_string();
     let err = MyBad {
         src: NamedSource::new("bad_file.rs", src),
-        highlight: (9, 6).into(),
+        highlight: (13, 8).into(),
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
@@ -92,8 +92,8 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
    ╭─[bad_file.rs:1:1]
  1 │ source
  2 │   👼🏼text
-   ·   ───┬──
-   ·      ╰── this bit here
+   ·     ───┬──
+   ·        ╰── this bit here
  3 │     here
    ╰────
   help: try doing it better next time?

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -157,10 +157,10 @@ fn single_line_with_tab_in_middle() -> Result<(), MietteError> {
 
     std::env::set_var("REPLACE_TABS", "4");
 
-    let src = "source\ntext\ttext\n    here".to_string();
+    let src = "source\ntext =\ttext\n    here".to_string();
     let err = MyBad {
         src: NamedSource::new("bad_file.rs", src),
-        highlight: (12, 4).into(),
+        highlight: (14, 4).into(),
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
@@ -169,7 +169,7 @@ fn single_line_with_tab_in_middle() -> Result<(), MietteError> {
   × oops!
    ╭─[bad_file.rs:1:1]
  1 │ source
- 2 │ text    text
+ 2 │ text =  text
    ·         ──┬─
    ·           ╰── this bit here
  3 │     here


### PR DESCRIPTION
Fixes #87 and #97.

Turns out that reliably determining the width of a string when displayed in a terminal is impossible without using ANSI escapes to get the current cursor position. Relying on the ANSI escapes is an option, but won't work if your output isn't a TTY. Supporting non-TTY output is important for things like redirecting error messages to a file, so I implemented a _mostly correct_ label alignment process that makes some specific tradeoffs. In the future, we could also add the escape-based option, and just fall back to this behavior on non-TTY output.

Back in https://github.com/zkat/miette/issues/87#issuecomment-1137930566, I had an idea for a hack to fix tab alignment while still respecting the terminal's tabstop setting. Unfortunately, I couldn't figure out a way to make this work for underlines, so the remaining option is to give up and replace tabs with spaces. This allows us to determine the visual width of the output reliably, but it does mean that we're ignoring the user's tabstop preferences. The original default behavior, where tabs were emitted verbatim and highlight alignment was broken, is pretty much never desirable, so I ended up just removing that option.

One of the issues with replacing tabs with a fixed number of spaces is that it will produce bad results if tabs are used for alignment in the middle of a line. To avoid this, we can emulate the behavior of the terminal, where tabs shift the cursor to the next tabstop rather than by a fixed width. Existing compilers that I checked seem to go both ways on this one. Gcc, clang, and rustc all emulate tabstops, while ghc uses a fixed width. I implemented the tabstop emulation option, which is a second breaking change, but this should be easy enough to swap out if we don't want it.

The other tradeoff here is that `unicode_width` isn't actually going to be able to predict the width of characters displayed on an arbitrary terminal. For example, 🏳️‍🌈 could show up as 1, 2, 3, or 4 columns. Predicting this is, in the general case, not possible. `unicode_width` is still better than assuming every character is 1 column though, so yay for incremental improvement.

Computers are a mess lol.