### PR TITLE
Declare minimum supported rust version at 1.56.0 (fixes CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [1.54.0, stable]
+        rust: [1.56.0, stable]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/miette"
 license = "Apache-2.0"
 readme = "README.md"
 edition = "2018"
+rust-version = "1.56.0"
 exclude = ["images/", "tests/", "miette-derive/"]
 
 [dependencies]


### PR DESCRIPTION
The latest release of `once_cell` (1.15.0) [bumped their msrv to 1.56.0][1]. Miette didn't previously declare an MSRV, but we have a CI pass that tests against rust 1.54.0. As a result, CI is currently broken.

[1]: https://github.com/matklad/once_cell/blob/master/CHANGELOG.md#1150

There are a few options here:

 - Bound our `once_cell` dependency as `<1.15.0`, and continue testing against rust 1.54.0.
 - Bump the CI pass to rust 1.56.0, but don't declare a MSRV for `miette` itself
 - Bump the CI pass and declare an MSRV (what I implemented in this PR)

I don't have strong opinions about which of these options to go for, it's really up to the `miette` maintainers. Happy to switch out this PR for one of the other options if you would prefer.