### PR TITLE
Implement `SourceCode` for `Vec<u8>`

### DIFF
--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -119,6 +119,17 @@ impl<'src> SourceCode for &'src [u8] {
     }
 }
 
+impl SourceCode for Vec<u8> {
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+        <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
+    }
+}
+
 impl SourceCode for str {
     fn read_span<'a>(
         &'a self,


### PR DESCRIPTION
SourceCode is implemented for &str, String, and &[u8] but it is missing an impl for `Vec<u8>`.