### PR TITLE
Fix wrong severity of related errors

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -281,7 +281,7 @@ impl GraphicalReportHandler {
         if let Some(related) = diagnostic.related() {
             writeln!(f)?;
             for rel in related {
-                match diagnostic.severity() {
+                match rel.severity() {
                     Some(Severity::Error) | None => write!(f, "Error: ")?,
                     Some(Severity::Warning) => write!(f, "Warning: ")?,
                     Some(Severity::Advice) => write!(f, "Advice: ")?,

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -132,7 +132,7 @@ impl NarratableReportHandler {
         if let Some(related) = diagnostic.related() {
             writeln!(f)?;
             for rel in related {
-                match diagnostic.severity() {
+                match rel.severity() {
                     Some(Severity::Error) | None => write!(f, "Error: ")?,
                     Some(Severity::Warning) => write!(f, "Warning: ")?,
                     Some(Severity::Advice) => write!(f, "Advice: ")?,
@@ -218,10 +218,10 @@ impl NarratableReportHandler {
         Ok(())
     }
 
-    fn render_context<'a>(
+    fn render_context(
         &self,
         f: &mut impl fmt::Write,
-        source: &'a dyn SourceCode,
+        source: &dyn SourceCode,
         context: &LabeledSpan,
         labels: &[LabeledSpan],
     ) -> fmt::Result {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -488,7 +488,7 @@ impl SourceOffset {
         Ok((
             loc.file().into(),
             fs::read_to_string(loc.file())
-                .map(|txt| Self::from_location(&txt, loc.line() as usize, loc.column() as usize))?,
+                .map(|txt| Self::from_location(txt, loc.line() as usize, loc.column() as usize))?,
         ))
     }
 }


### PR DESCRIPTION
Currently, the severity of the parent error is shown as the severity of related errors.
This PR fix it.

Closes #232