### PR TITLE
SourceCode provides access to bytes

### DIFF
--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -53,4 +53,8 @@ impl SourceCode for NamedSource {
             contents.line_count(),
         )))
     }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.inner().source_bytes()
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -198,7 +198,7 @@ pub trait SourceCode: Send + Sync {
 
     /// Borrow the source bytes as a string slice.
     /// Returns None if the source is not a valid utf-8 string.
-    fn source_utf8(&self) -> Result<&str, std::str::Utf8Error> {
+    fn source_str(&self) -> Result<&str, std::str::Utf8Error> {
         std::str::from_utf8(self.source_bytes())
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -192,6 +192,15 @@ pub trait SourceCode: Send + Sync {
         context_lines_before: usize,
         context_lines_after: usize,
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError>;
+
+    /// Borrow the source bytes in their entirety.
+    fn source_bytes(&self) -> &[u8];
+
+    /// Borrow the source bytes as a string slice.
+    /// Returns None if the source is not a valid utf-8 string.
+    fn source_utf8(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.source_bytes())
+    }
 }
 
 /// A labeled [`SourceSpan`].

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -108,8 +108,8 @@ impl SourceCode for [u8] {
     }
 
     fn source_bytes(&self) -> &[u8] {
-        &self[..]
-    }    
+        self
+    }
 }
 
 impl<'src> SourceCode for &'src [u8] {
@@ -125,8 +125,6 @@ impl<'src> SourceCode for &'src [u8] {
     fn source_bytes(&self) -> &[u8] {
         self
     }
-
-    
 }
 
 impl SourceCode for Vec<u8> {
@@ -161,7 +159,7 @@ impl SourceCode for str {
 
     fn source_bytes(&self) -> &[u8] {
         self.as_bytes()
-    }    
+    }
 }
 
 /// Makes `src: &'static str` or `struct S<'a> { src: &'a str }` usable.

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -106,6 +106,10 @@ impl SourceCode for [u8] {
         let contents = context_info(self, span, context_lines_before, context_lines_after)?;
         Ok(Box::new(contents))
     }
+
+    fn source_bytes(&self) -> &[u8] {
+        &self[..]
+    }    
 }
 
 impl<'src> SourceCode for &'src [u8] {
@@ -117,6 +121,12 @@ impl<'src> SourceCode for &'src [u8] {
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
+
+    fn source_bytes(&self) -> &[u8] {
+        self
+    }
+
+    
 }
 
 impl SourceCode for Vec<u8> {
@@ -127,6 +137,10 @@ impl SourceCode for Vec<u8> {
         context_lines_after: usize,
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
+    }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.as_slice()
     }
 }
 
@@ -144,6 +158,10 @@ impl SourceCode for str {
             context_lines_after,
         )
     }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }    
 }
 
 /// Makes `src: &'static str` or `struct S<'a> { src: &'a str }` usable.
@@ -156,6 +174,10 @@ impl<'s> SourceCode for &'s str {
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
 }
 
 impl SourceCode for String {
@@ -166,6 +188,10 @@ impl SourceCode for String {
         context_lines_after: usize,
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
+    }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.as_bytes()
     }
 }
 
@@ -178,6 +204,10 @@ impl<T: ?Sized + SourceCode> SourceCode for Arc<T> {
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         self.as_ref()
             .read_span(span, context_lines_before, context_lines_after)
+    }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.as_ref().source_bytes()
     }
 }
 
@@ -198,6 +228,10 @@ where
     ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
         self.as_ref()
             .read_span(span, context_lines_before, context_lines_after)
+    }
+
+    fn source_bytes(&self) -> &[u8] {
+        self.as_ref().source_bytes()
     }
 }
 


### PR DESCRIPTION
I would like to be able to use `&NamedSource` as the input to parsing and lexing functions that use and borrow from the source already stored in the `NamedSource::inner()` instead of passing another copy. This could simplify the API for a basic parse function to something like this:

```rust
pub fn parse(source: &NamedSource) -> Result<Tokens<'_>> {
   let chars = source.inner().source_str()?.char_indices();
   ...
}
```

This PR adds the `SourceCode::source_bytes()` and `SourceCode::source_str()` functions to enable this use case.