### PR TITLE
feat: Add style `tags` field for graphical theme.

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,9 +25,6 @@ impl Default for RgbColors {
     }
 }
 
-/// Function to format a message before rendering.
-pub type MessageFormatter = dyn Fn(String) -> String;
-
 /**
 Create a custom [`MietteHandler`] from options.
 
@@ -58,7 +55,6 @@ pub struct MietteHandlerOpts {
     pub(crate) context_lines: Option<usize>,
     pub(crate) tab_width: Option<usize>,
     pub(crate) with_cause_chain: Option<bool>,
-    pub(crate) message_formatter: Option<Box<MessageFormatter>>,
 }
 
 impl MietteHandlerOpts {
@@ -168,11 +164,6 @@ impl MietteHandlerOpts {
         self
     }
 
-    pub fn message_formatter<F: MessageFormatter>(mut self, formatter: F) -> Self {
-        self.message_formatter = Some(Box::new(formatter));
-        self
-    }
-
     /// Builds a [`MietteHandler`] from this builder.
     pub fn build(self) -> MietteHandler {
         let graphical = self.is_graphical();
@@ -221,7 +212,11 @@ impl MietteHandlerOpts {
             } else {
                 ThemeStyles::none()
             };
-            let theme = self.theme.unwrap_or(GraphicalTheme { characters, styles });
+            let theme = self.theme.unwrap_or(GraphicalTheme {
+                characters,
+                styles,
+                tags: std::collections::HashMap::new(),
+            });
             let mut handler = GraphicalReportHandler::new()
                 .with_width(width)
                 .with_links(linkify)
@@ -241,9 +236,6 @@ impl MietteHandlerOpts {
             }
             if let Some(w) = self.tab_width {
                 handler = handler.tab_width(w);
-            }
-            if let Some(formatter) = self.message_formatter {
-                handler = handler.with_message_formatter(formatter);
             }
             MietteHandler {
                 inner: Box::new(handler),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,6 +25,9 @@ impl Default for RgbColors {
     }
 }
 
+/// Function to format a message before rendering.
+pub type MessageFormatter = dyn Fn(String) -> String;
+
 /**
 Create a custom [`MietteHandler`] from options.
 
@@ -55,6 +58,7 @@ pub struct MietteHandlerOpts {
     pub(crate) context_lines: Option<usize>,
     pub(crate) tab_width: Option<usize>,
     pub(crate) with_cause_chain: Option<bool>,
+    pub(crate) message_formatter: Option<Box<MessageFormatter>>,
 }
 
 impl MietteHandlerOpts {
@@ -164,6 +168,11 @@ impl MietteHandlerOpts {
         self
     }
 
+    pub fn message_formatter<F: MessageFormatter>(mut self, formatter: F) -> Self {
+        self.message_formatter = Some(Box::new(formatter));
+        self
+    }
+
     /// Builds a [`MietteHandler`] from this builder.
     pub fn build(self) -> MietteHandler {
         let graphical = self.is_graphical();
@@ -232,6 +241,9 @@ impl MietteHandlerOpts {
             }
             if let Some(w) = self.tab_width {
                 handler = handler.tab_width(w);
+            }
+            if let Some(formatter) = self.message_formatter {
+                handler = handler.with_message_formatter(formatter);
             }
             MietteHandler {
                 inner: Box::new(handler),

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -6,9 +6,7 @@ use unicode_width::UnicodeWidthChar;
 use crate::diagnostic_chain::DiagnosticChain;
 use crate::handlers::theme::*;
 use crate::protocol::{Diagnostic, Severity};
-use crate::{
-    LabeledSpan, MessageFormatter, MietteError, ReportHandler, SourceCode, SourceSpan, SpanContents,
-};
+use crate::{LabeledSpan, MietteError, ReportHandler, SourceCode, SourceSpan, SpanContents};
 
 /**
 A [`ReportHandler`] that displays a given [`Report`](crate::Report) in a
@@ -32,7 +30,6 @@ pub struct GraphicalReportHandler {
     pub(crate) context_lines: usize,
     pub(crate) tab_width: usize,
     pub(crate) with_cause_chain: bool,
-    pub(crate) message_formatter: Option<Box<MessageFormatter>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,7 +51,6 @@ impl GraphicalReportHandler {
             context_lines: 1,
             tab_width: 4,
             with_cause_chain: true,
-            message_formatter: None,
         }
     }
 
@@ -68,7 +64,6 @@ impl GraphicalReportHandler {
             context_lines: 1,
             tab_width: 4,
             with_cause_chain: true,
-            message_formatter: None,
         }
     }
 
@@ -136,11 +131,6 @@ impl GraphicalReportHandler {
     /// Sets the number of lines of context to show around each error.
     pub fn with_context_lines(mut self, lines: usize) -> Self {
         self.context_lines = lines;
-        self
-    }
-
-    pub fn with_message_formatter<F: MessageFormatter>(mut self, formatter: F) -> Self {
-        self.message_formatter = Some(Box::new(formatter));
         self
     }
 }
@@ -226,9 +216,6 @@ impl GraphicalReportHandler {
             .subsequent_indent(&rest_indent);
         let mut message = diagnostic.to_string();
 
-        if let Some(formatter) = self.message_formatter {
-            message = formatter(message);
-        }
 
         writeln!(f, "{}", textwrap::fill(&message, opts))?;
 

--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -1,5 +1,6 @@
 use is_terminal::IsTerminal;
 use owo_colors::Style;
+use std::collections::HashMap;
 
 /**
 Theme used by [`GraphicalReportHandler`](crate::GraphicalReportHandler) to
@@ -18,6 +19,8 @@ pub struct GraphicalTheme {
     pub characters: ThemeCharacters,
     /// Styles to be used for painting.
     pub styles: ThemeStyles,
+    /// Tags to be used for styling.
+    pub tags: HashMap<String, Style>,
 }
 
 impl GraphicalTheme {
@@ -26,6 +29,7 @@ impl GraphicalTheme {
         Self {
             characters: ThemeCharacters::ascii(),
             styles: ThemeStyles::ansi(),
+            tags: HashMap::new(),
         }
     }
 
@@ -41,6 +45,7 @@ impl GraphicalTheme {
         Self {
             characters: ThemeCharacters::unicode(),
             styles: ThemeStyles::ansi(),
+            tags: HashMap::new(),
         }
     }
 
@@ -50,6 +55,7 @@ impl GraphicalTheme {
         Self {
             characters: ThemeCharacters::unicode(),
             styles: ThemeStyles::none(),
+            tags: HashMap::new(),
         }
     }
 
@@ -62,6 +68,7 @@ impl GraphicalTheme {
         Self {
             characters: ThemeCharacters::ascii(),
             styles: ThemeStyles::none(),
+            tags: HashMap::new(),
         }
     }
 }

--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -6,9 +6,10 @@ use std::collections::HashMap;
 Theme used by [`GraphicalReportHandler`](crate::GraphicalReportHandler) to
 render fancy [`Diagnostic`](crate::Diagnostic) reports.
 
-A theme consists of two things: the set of characters to be used for drawing,
-and the
-[`owo_colors::Style`](https://docs.rs/owo-colors/latest/owo_colors/struct.Style.html)s to be used to paint various items.
+A theme consists of three things: the set of characters to be used for drawing,
+the
+[`owo_colors::Style`](https://docs.rs/owo-colors/latest/owo_colors/struct.Style.html)s to be used to paint various items, and an optional set of tags (in the format of <tag>text</tag>) to be
+styled with [`owo_colors::Style`](https://docs.rs/owo-colors/latest/owo_colors/struct.Style.html).
 
 You can create your own custom graphical theme using this type, or you can use
 one of the predefined ones using the methods below.


### PR DESCRIPTION
Hey @zkat, great library.

We're in the process of migrating to miette from our own custom error handler and there's 1 feature we use heavily that miette does not support, and that's "style tags" within error messages. Here's an example of this:

```rust
#[error("Unable to unpack <path>{0}</path>, unsupported archive format <label>{1}</label>.")]
UnsupportedArchiveFormat(PathBuf, String),
```

It's basically HTML-like tags within the error message, that we replace with ANSI coloring/links/etc before rendering to the terminal. This is really nice as we can use these same tags in error messages, logs, and tracing, and all of them render in a similar fashion.

I originally approached this PR by supporting a "message formatting function", but because the graphical handler requires `Clone` + `Debug`, this wasn't easy to set and pass around. So instead I thought, why not just support the tags natively? As part of the theme perhaps? And that's what this PR does.

Here's an example of the terminal output when writing the test:
<img width="1512" alt="Screenshot 2023-04-08 at 4 39 12 PM" src="https://user-images.githubusercontent.com/143744/230747220-f46c8283-1018-46c4-ad13-69d2def08879.png">

Another question I have:

- Should the json/narratable handlers remove all tags? Or preserve them? If yes, I think this one will require using regex.
