### PR TITLE
Allow inner source type of a NamedSource to be borrowed directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ struct MyBad {
     // The Source that we're gonna be printing snippets out of.
     // This can be a String if you don't have or care about file names.
     #[source_code]
-    src: NamedSource,
+    src: NamedSource<String>,
     // Snippets and highlights can be included in the diagnostic!
     #[label("This bit here")]
     bad_bit: SourceSpan,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!     // The Source that we're gonna be printing snippets out of.
 //!     // This can be a String if you don't have or care about file names.
 //!     #[source_code]
-//!     src: NamedSource,
+//!     src: NamedSource<String>,
 //!     // Snippets and highlights can be included in the diagnostic!
 //!     #[label("This bit here")]
 //!     bad_bit: SourceSpan,

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -41,7 +41,7 @@ fn empty_source() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -74,7 +74,7 @@ fn single_line_highlight_span_full_line() {
     #[diagnostic(severity(Error))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<&'static str>,
         #[label("This bit here")]
         bad_bit: SourceSpan,
     }
@@ -106,7 +106,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -143,7 +143,7 @@ fn single_line_with_two_tabs() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -182,7 +182,7 @@ fn single_line_with_tab_in_middle() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -221,7 +221,7 @@ fn single_line_highlight() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -293,7 +293,7 @@ fn single_line_highlight_offset_zero() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -329,7 +329,7 @@ fn single_line_higlight_offset_end_of_line() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -365,7 +365,7 @@ fn single_line_higlight_include_end_of_line() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -402,7 +402,7 @@ fn single_line_higlight_include_end_of_line_crlf() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -439,7 +439,7 @@ fn single_line_highlight_with_empty_span() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -476,7 +476,7 @@ fn single_line_highlight_no_label() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label]
         highlight: SourceSpan,
     }
@@ -512,7 +512,7 @@ fn single_line_highlight_at_line_start() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -549,7 +549,7 @@ fn multiple_same_line_highlights() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "x"]
         highlight1: SourceSpan,
         #[label = "y"]
@@ -594,7 +594,7 @@ fn multiple_same_line_highlights_with_tabs_in_middle() -> Result<(), MietteError
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "x"]
         highlight1: SourceSpan,
         #[label = "y"]
@@ -641,7 +641,7 @@ fn multiline_highlight_adjacent() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "these two lines"]
         highlight: SourceSpan,
     }
@@ -677,7 +677,7 @@ fn multiline_highlight_flyby() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "block 1"]
         highlight1: SourceSpan,
         #[label = "block 2"]
@@ -728,7 +728,7 @@ fn multiline_highlight_no_label() -> Result<(), MietteError> {
         #[source]
         source: Inner,
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "block 1"]
         highlight1: SourceSpan,
         #[label]
@@ -792,7 +792,7 @@ fn multiple_multiline_highlights_adjacent() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "this bit here"]
         highlight1: SourceSpan,
         #[label = "also this bit"]
@@ -838,7 +838,7 @@ fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> 
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "this bit here"]
         highlight1: SourceSpan,
         #[label = "also this bit"]
@@ -866,7 +866,7 @@ fn multiple_multiline_highlights_overlapping_offsets() -> Result<(), MietteError
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "this bit here"]
         highlight1: SourceSpan,
         #[label = "also this bit"]
@@ -948,7 +948,7 @@ fn related() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
         #[related]
@@ -1004,7 +1004,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
         #[related]
@@ -1064,7 +1064,7 @@ fn related_severity() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
         #[related]
@@ -1081,7 +1081,7 @@ fn related_severity() -> Result<(), MietteError> {
         )]
         Error {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -1094,7 +1094,7 @@ fn related_severity() -> Result<(), MietteError> {
         )]
         Warning {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -1107,7 +1107,7 @@ fn related_severity() -> Result<(), MietteError> {
         )]
         Advice {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -1190,7 +1190,7 @@ fn zero_length_eol_span() {
     #[diagnostic(severity(Error))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<&'static str>,
         #[label("This bit here")]
         bad_bit: SourceSpan,
     }

--- a/tests/narrated.rs
+++ b/tests/narrated.rs
@@ -29,7 +29,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -65,7 +65,7 @@ fn single_line_highlight() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -101,7 +101,7 @@ fn single_line_highlight_offset_zero() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -136,7 +136,7 @@ fn single_line_highlight_with_empty_span() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -172,7 +172,7 @@ fn single_line_highlight_no_label() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label]
         highlight: SourceSpan,
     }
@@ -208,7 +208,7 @@ fn single_line_highlight_at_line_start() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
     }
@@ -244,7 +244,7 @@ fn multiple_same_line_highlights() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "x"]
         highlight1: SourceSpan,
         #[label = "y"]
@@ -288,7 +288,7 @@ fn multiline_highlight_adjacent() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "these two lines"]
         highlight: SourceSpan,
     }
@@ -325,7 +325,7 @@ fn multiline_highlight_flyby() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "block 1"]
         highlight1: SourceSpan,
         #[label = "block 2"]
@@ -378,7 +378,7 @@ fn multiline_highlight_no_label() -> Result<(), MietteError> {
         #[source]
         source: Inner,
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "block 1"]
         highlight1: SourceSpan,
         #[label]
@@ -444,7 +444,7 @@ fn multiple_multiline_highlights_adjacent() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "this bit here"]
         highlight1: SourceSpan,
         #[label = "also this bit"]
@@ -492,7 +492,7 @@ fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> 
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "this bit here"]
         highlight1: SourceSpan,
         #[label = "also this bit"]
@@ -520,7 +520,7 @@ fn multiple_multiline_highlights_overlapping_offsets() -> Result<(), MietteError
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label = "this bit here"]
         highlight1: SourceSpan,
         #[label = "also this bit"]
@@ -559,7 +559,7 @@ fn related() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
         #[related]
@@ -614,7 +614,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
     #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
     struct MyBad {
         #[source_code]
-        src: NamedSource,
+        src: NamedSource<String>,
         #[label("this bit here")]
         highlight: SourceSpan,
         #[related]

--- a/tests/test_derive_attr.rs
+++ b/tests/test_derive_attr.rs
@@ -10,7 +10,7 @@ fn enum_uses_base_attr() {
     enum MyBad {
         Only {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -32,7 +32,7 @@ fn enum_uses_variant_attr() {
         #[diagnostic(code(error::on::variant))]
         Only {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -55,7 +55,7 @@ fn multiple_attrs_allowed_on_item() {
     enum MyBad {
         Only {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -79,7 +79,7 @@ fn multiple_attrs_allowed_on_variant() {
         #[diagnostic(help("try doing it correctly"))]
         Only {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -104,7 +104,7 @@ fn attrs_can_be_split_between_item_and_variants() {
         #[diagnostic(url("https://example.com/foo/bar"))]
         Only {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },
@@ -130,7 +130,7 @@ fn attr_not_required() {
     enum MyBad {
         Only {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         },

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -20,7 +20,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         }
@@ -66,7 +66,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         }
@@ -112,7 +112,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         }
@@ -158,7 +158,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         }
@@ -204,7 +204,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label]
             highlight: SourceSpan,
         }
@@ -249,7 +249,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
         }
@@ -295,7 +295,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "x"]
             highlight1: SourceSpan,
             #[label = "y"]
@@ -361,7 +361,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "these two lines"]
             highlight: SourceSpan,
         }
@@ -407,7 +407,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "block 1"]
             highlight1: SourceSpan,
             #[label = "block 2"]
@@ -472,7 +472,7 @@ mod json_report_handler {
             #[source]
             source: Inner,
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "block 1"]
             highlight1: SourceSpan,
             #[label]
@@ -546,7 +546,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "this bit here"]
             highlight1: SourceSpan,
             #[label = "also this bit"]
@@ -602,7 +602,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "this bit here"]
             highlight1: SourceSpan,
             #[label = "also this bit"]
@@ -658,7 +658,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label = "this bit here"]
             highlight1: SourceSpan,
             #[label = "also this bit"]
@@ -742,7 +742,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
             #[related]
@@ -836,7 +836,7 @@ mod json_report_handler {
         #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
         struct MyBad {
             #[source_code]
-            src: NamedSource,
+            src: NamedSource<String>,
             #[label("this bit here")]
             highlight: SourceSpan,
             #[related]


### PR DESCRIPTION
Fixes: #236 

This is a simple direct implementation that just makes NamedSource generic over a SourceCode type parameter. It would be nice if we could give the type parameter a sensible default so that existing diagnostics don't break. I'll test various approaches to make this more backwards compatible over the next few days. 

Maybe keeping the source in a `Box`, allowing `S` to be `?Sized`, and then defaulting `S` to `dyn SourceCode + 'static` but I'm not sure how to change the type of `NamedSource::new` to allow for that, since function arguments must be `Sized`.