### PR TITLE
feat: Constify many functions

### DIFF
--- a/src/eyreish/ptr.rs
+++ b/src/eyreish/ptr.rs
@@ -43,7 +43,7 @@ where
         Box::from_raw(self.ptr.as_ptr())
     }
 
-    pub(crate) fn by_ref<'a>(&self) -> Ref<'a, T> {
+    pub(crate) const fn by_ref<'a>(&self) -> Ref<'a, T> {
         Ref {
             ptr: self.ptr,
             lifetime: PhantomData,
@@ -91,7 +91,7 @@ where
         }
     }
 
-    pub(crate) fn from_raw(ptr: NonNull<T>) -> Self {
+    pub(crate) const fn from_raw(ptr: NonNull<T>) -> Self {
         Ref {
             ptr,
             lifetime: PhantomData,
@@ -112,7 +112,7 @@ where
         }
     }
 
-    pub(crate) fn as_ptr(self) -> *const T {
+    pub(crate) const fn as_ptr(self) -> *const T {
         self.ptr.as_ptr() as *const T
     }
 
@@ -154,7 +154,7 @@ where
         }
     }
 
-    pub(crate) fn by_ref(self) -> Ref<'a, T> {
+    pub(crate) const fn by_ref(self) -> Ref<'a, T> {
         Ref {
             ptr: self.ptr,
             lifetime: PhantomData,

--- a/src/handlers/debug.rs
+++ b/src/handlers/debug.rs
@@ -13,7 +13,7 @@ pub struct DebugReportHandler;
 impl DebugReportHandler {
     /// Create a new [`NarratableReportHandler`](crate::NarratableReportHandler)
     /// There are no customization options.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -13,7 +13,7 @@ pub struct JSONReportHandler;
 impl JSONReportHandler {
     /// Create a new [`JSONReportHandler`]. There are no customization
     /// options.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }
@@ -49,7 +49,7 @@ impl fmt::Display for Escape<'_> {
     }
 }
 
-fn escape(input: &'_ str) -> Escape<'_> {
+const fn escape(input: &'_ str) -> Escape<'_> {
     Escape(input)
 }
 

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -21,7 +21,7 @@ pub struct NarratableReportHandler {
 impl NarratableReportHandler {
     /// Create a new [`NarratableReportHandler`]. There are no customization
     /// options.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             footer: None,
             context_lines: 1,
@@ -31,13 +31,13 @@ impl NarratableReportHandler {
 
     /// Include the cause chain of the top-level error in the report, if
     /// available.
-    pub fn with_cause_chain(mut self) -> Self {
+    pub const fn with_cause_chain(mut self) -> Self {
         self.with_cause_chain = true;
         self
     }
 
     /// Do not include the cause chain of the top-level error in the report.
-    pub fn without_cause_chain(mut self) -> Self {
+    pub const fn without_cause_chain(mut self) -> Self {
         self.with_cause_chain = false;
         self
     }
@@ -49,7 +49,7 @@ impl NarratableReportHandler {
     }
 
     /// Sets the number of lines of context to show around each error.
-    pub fn with_context_lines(mut self, lines: usize) -> Self {
+    pub const fn with_context_lines(mut self, lines: usize) -> Self {
         self.context_lines = lines;
         self
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -241,10 +241,10 @@ pub struct LabeledSpan {
 
 impl LabeledSpan {
     /// Makes a new labeled span.
-    pub fn new(label: Option<String>, offset: ByteOffset, len: usize) -> Self {
+    pub const fn new(label: Option<String>, offset: ByteOffset, len: usize) -> Self {
         Self {
             label,
-            span: (offset, len).into(),
+            span: SourceSpan::new(SourceOffset(offset), SourceOffset(len)),
         }
     }
 
@@ -310,22 +310,22 @@ impl LabeledSpan {
     }
 
     /// Returns a reference to the inner [`SourceSpan`].
-    pub fn inner(&self) -> &SourceSpan {
+    pub const fn inner(&self) -> &SourceSpan {
         &self.span
     }
 
     /// Returns the 0-based starting byte offset.
-    pub fn offset(&self) -> usize {
+    pub const fn offset(&self) -> usize {
         self.span.offset()
     }
 
     /// Returns the number of bytes this `LabeledSpan` spans.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.span.len()
     }
 
     /// True if this `LabeledSpan` is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.span.is_empty()
     }
 }
@@ -422,7 +422,7 @@ pub struct MietteSpanContents<'a> {
 
 impl<'a> MietteSpanContents<'a> {
     /// Make a new [`MietteSpanContents`] object.
-    pub fn new(
+    pub const fn new(
         data: &'a [u8],
         span: SourceSpan,
         line: usize,
@@ -440,7 +440,7 @@ impl<'a> MietteSpanContents<'a> {
     }
 
     /// Make a new [`MietteSpanContents`] object, with a name for its 'file'.
-    pub fn new_named(
+    pub const fn new_named(
         name: String,
         data: &'a [u8],
         span: SourceSpan,
@@ -492,7 +492,7 @@ pub struct SourceSpan {
 
 impl SourceSpan {
     /// Create a new [`SourceSpan`].
-    pub fn new(start: SourceOffset, length: SourceOffset) -> Self {
+    pub const fn new(start: SourceOffset, length: SourceOffset) -> Self {
         Self {
             offset: start,
             length: length.offset(),
@@ -500,18 +500,18 @@ impl SourceSpan {
     }
 
     /// The absolute offset, in bytes, from the beginning of a [`SourceCode`].
-    pub fn offset(&self) -> usize {
+    pub const fn offset(&self) -> usize {
         self.offset.offset()
     }
 
     /// Total length of the [`SourceSpan`], in bytes.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.length
     }
 
     /// Whether this [`SourceSpan`] has a length of zero. It may still be useful
     /// to point to a specific point.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.length == 0
     }
 }
@@ -589,7 +589,7 @@ pub struct SourceOffset(ByteOffset);
 
 impl SourceOffset {
     /// Actual byte offset.
-    pub fn offset(&self) -> ByteOffset {
+    pub const fn offset(&self) -> ByteOffset {
         self.0
     }
 


### PR DESCRIPTION
This is primarily aimed at making `SourceSpan` and `SourceOffset` usable in const contexts.

Constifiable functions were found with the `clippy::missing_const_for_fn` lint, though it reported at least two false positives.

Fixes #261