### PR TITLE
fix(protocol): add StdError impl for Box<dyn Diagnostic + Send + Sync>

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -69,14 +69,26 @@ pub trait Diagnostic: std::error::Error {
     }
 }
 
-impl std::error::Error for Box<dyn Diagnostic> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        (**self).source()
-    }
+macro_rules! box_impls {
+    ($($box_type:ty),*) => {
+        $(
+            impl std::error::Error for $box_type {
+                fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                    (**self).source()
+                }
 
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        self.source()
+                fn cause(&self) -> Option<&dyn std::error::Error> {
+                    self.source()
+                }
+            }
+        )*
     }
+}
+
+box_impls! {
+    Box<dyn Diagnostic>,
+    Box<dyn Diagnostic + Send>,
+    Box<dyn Diagnostic + Send + Sync>
 }
 
 impl<T: Diagnostic + Send + Sync + 'static> From<T>

--- a/tests/test_derive_source_chain.rs
+++ b/tests/test_derive_source_chain.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use miette::{miette, Diagnostic, Report};
+use thiserror::Error;
+
+#[test]
+fn test_source() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Bar")]
+    struct Bar;
+
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Foo")]
+    struct Foo {
+        #[source]
+        bar: Bar,
+    }
+
+    let e = miette!(Foo { bar: Bar });
+    let mut chain = e.chain();
+
+    assert_eq!("Foo", chain.next().unwrap().to_string());
+    assert_eq!("Bar", chain.next().unwrap().to_string());
+    assert!(chain.next().is_none());
+}
+
+#[test]
+fn test_source_boxed() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Bar")]
+    struct Bar;
+
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Foo")]
+    struct Foo {
+        #[source]
+        bar: Box<dyn Diagnostic + Send + Sync>,
+    }
+
+    let error = miette!(Foo { bar: Box::new(Bar) });
+
+    let mut chain = error.chain();
+
+    assert_eq!("Foo", chain.next().unwrap().to_string());
+    assert_eq!("Bar", chain.next().unwrap().to_string());
+    assert!(chain.next().is_none());
+}
+
+#[test]
+fn test_source_arc() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Bar")]
+    struct Bar;
+
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Foo")]
+    struct Foo {
+        #[source]
+        bar: Arc<dyn Diagnostic + Send + Sync>,
+    }
+
+    let error = miette!(Foo { bar: Arc::new(Bar) });
+
+    let mut chain = error.chain();
+
+    assert_eq!("Foo", chain.next().unwrap().to_string());
+    assert_eq!("Bar", chain.next().unwrap().to_string());
+    assert!(chain.next().is_none());
+}

--- a/tests/test_derive_source_chain.rs
+++ b/tests/test_derive_source_chain.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use miette::{miette, Diagnostic, Report};
+use miette::{miette, Diagnostic};
 use thiserror::Error;
 
 #[test]


### PR DESCRIPTION
Adds `std::error::Error` impls for `Box<dyn Diagnostic + Send + Sync>` (and other variants).

Fixes #272.