### PR TITLE
chore: update dependencies to their latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ unicode-width = "0.1.9"
 
 owo-colors = { version = "3.0.0", optional = true }
 is-terminal = { version = "0.4.0", optional = true }
-textwrap = { version = "0.15.0", optional = true }
+textwrap = { version = "0.16.0", optional = true }
 supports-hyperlinks = { version = "2.0.0", optional = true }
 supports-color = { version = "2.0.0", optional = true }
 supports-unicode = { version = "2.0.0", optional = true }
 backtrace = { version = "0.3.61", optional = true }
-terminal_size = { version = "0.1.17", optional = true }
+terminal_size = { version = "0.2.6", optional = true }
 backtrace-ext = { version = "0.2.1", optional = true }
 serde = { version = "1.0.162", features = ["derive"], optional = true }
 


### PR DESCRIPTION
Updated `textwrap` and `terminal_size` to their latest version, as those two crates had a breaking release.

Most changes seem to be simply fixes and breaking changes on API that are not used in miette.
