### PR TITLE
Remove dependency on `is-terminal` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ once_cell = "1.8.0"
 unicode-width = "0.1.9"
 
 owo-colors = { version = "3.0.0", optional = true }
-is-terminal = { version = "0.4.0", optional = true }
 textwrap = { version = "0.15.0", optional = true }
 supports-hyperlinks = { version = "2.0.0", optional = true }
 supports-color = { version = "2.0.0", optional = true }
@@ -48,7 +47,6 @@ default = []
 no-format-args-capture = []
 fancy-no-backtrace = [
     "owo-colors",
-    "is-terminal",
     "textwrap",
     "terminal_size",
     "supports-hyperlinks",

--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -1,5 +1,5 @@
-use is_terminal::IsTerminal;
 use owo_colors::Style;
+use std::io::IsTerminal;
 
 /**
 Theme used by [`GraphicalReportHandler`](crate::GraphicalReportHandler) to


### PR DESCRIPTION
Since Rust version `1.70.0`, the trait `std::io::IsTerminal` has been available that does the same thing.