### PR TITLE
Add support for primary label in specifying line/col information

### DIFF
--- a/miette-derive/src/lib.rs
+++ b/miette-derive/src/lib.rs
@@ -19,7 +19,15 @@ mod utils;
 
 #[proc_macro_derive(
     Diagnostic,
-    attributes(diagnostic, source_code, label, related, help, diagnostic_source)
+    attributes(
+        diagnostic,
+        source_code,
+        label,
+        primary_label,
+        related,
+        help,
+        diagnostic_source
+    )
 )]
 pub fn derive_diagnostic(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/miette-derive/src/lib.rs
+++ b/miette-derive/src/lib.rs
@@ -19,15 +19,7 @@ mod utils;
 
 #[proc_macro_derive(
     Diagnostic,
-    attributes(
-        diagnostic,
-        source_code,
-        label,
-        primary_label,
-        related,
-        help,
-        diagnostic_source
-    )
+    attributes(diagnostic, source_code, label, related, help, diagnostic_source)
 )]
 pub fn derive_diagnostic(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -391,7 +391,10 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         let (contents, lines) = self.get_lines(source, context.inner())?;
 
-        let primary_label = labels.iter().find(|label| label.primary());
+        let primary_label = labels
+            .iter()
+            .find(|label| label.primary())
+            .or_else(|| labels.first());
 
         // sorting is your friend
         let labels = labels

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -391,6 +391,8 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         let (contents, lines) = self.get_lines(source, context.inner())?;
 
+        let primary_label = labels.iter().find(|label| label.primary());
+
         // sorting is your friend
         let labels = labels
             .iter()
@@ -431,19 +433,33 @@ impl GraphicalReportHandler {
             self.theme.characters.hbar,
         )?;
 
-        if let Some(source_name) = contents.name() {
+        // If there is a primary label, then use its span
+        // as the reference point for line/column information.
+        let primary_contents = match primary_label {
+            Some(label) => source
+                .read_span(label.inner(), 0, 0)
+                .map_err(|_| fmt::Error)?,
+            None => contents,
+        };
+
+        if let Some(source_name) = primary_contents.name() {
             let source_name = source_name.style(self.theme.styles.link);
             writeln!(
                 f,
                 "[{}:{}:{}]",
                 source_name,
-                contents.line() + 1,
-                contents.column() + 1
+                primary_contents.line() + 1,
+                primary_contents.column() + 1
             )?;
         } else if lines.len() <= 1 {
             writeln!(f, "{}", self.theme.characters.hbar.to_string().repeat(3))?;
         } else {
-            writeln!(f, "[{}:{}]", contents.line() + 1, contents.column() + 1)?;
+            writeln!(
+                f,
+                "[{}:{}]",
+                primary_contents.line() + 1,
+                primary_contents.column() + 1
+            )?;
         }
 
         // Now it's time for the fun part--actually rendering everything!

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -292,14 +292,16 @@ fn test_serialize_miette_diagnostic() {
                     "offset": 0,
                     "length": 0
                 },
-                "label": "label1"
+                "label": "label1",
+                "primary": false
             },
             {
                 "span": {
                     "offset": 1,
                     "length": 2
                 },
-                "label": "label2"
+                "label": "label2",
+                "primary": false
             }
         ]
     });
@@ -350,14 +352,16 @@ fn test_deserialize_miette_diagnostic() {
                     "offset": 0,
                     "length": 0
                 },
-                "label": "label1"
+                "label": "label1",
+                "primary": false
             },
             {
                 "span": {
                     "offset": 1,
                     "length": 2
                 },
-                "label": "label2"
+                "label": "label2",
+                "primary": false
             }
         ]
     });

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -252,7 +252,7 @@ impl MietteDiagnostic {
     /// ```
     pub fn and_labels(mut self, labels: impl IntoIterator<Item = LabeledSpan>) -> Self {
         let mut all_labels = self.labels.unwrap_or_default();
-        all_labels.extend(labels.into_iter());
+        all_labels.extend(labels);
         self.labels = Some(all_labels);
         self
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -249,6 +249,7 @@ pub struct LabeledSpan {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     label: Option<String>,
     span: SourceSpan,
+    primary: bool,
 }
 
 impl LabeledSpan {
@@ -257,6 +258,7 @@ impl LabeledSpan {
         Self {
             label,
             span: SourceSpan::new(SourceOffset(offset), SourceOffset(len)),
+            primary: false,
         }
     }
 
@@ -265,6 +267,16 @@ impl LabeledSpan {
         Self {
             label,
             span: span.into(),
+            primary: false,
+        }
+    }
+
+    /// Makes a new labeled primary span using an existing span.
+    pub fn new_primary_with_span(label: Option<String>, span: impl Into<SourceSpan>) -> Self {
+        Self {
+            label,
+            span: span.into(),
+            primary: true,
         }
     }
 
@@ -340,6 +352,11 @@ impl LabeledSpan {
     pub const fn is_empty(&self) -> bool {
         self.span.is_empty()
     }
+
+    /// True if this `LabeledSpan` is a primary span.
+    pub const fn primary(&self) -> bool {
+        self.primary
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -350,7 +367,8 @@ fn test_serialize_labeled_span() {
     assert_eq!(
         json!(LabeledSpan::new(None, 0, 0)),
         json!({
-            "span": { "offset": 0, "length": 0 }
+            "span": { "offset": 0, "length": 0, },
+            "primary": false,
         })
     );
 
@@ -358,7 +376,8 @@ fn test_serialize_labeled_span() {
         json!(LabeledSpan::new(Some("label".to_string()), 0, 0)),
         json!({
             "label": "label",
-            "span": { "offset": 0, "length": 0 }
+            "span": { "offset": 0, "length": 0, },
+            "primary": false, 
         })
     )
 }
@@ -370,20 +389,23 @@ fn test_deserialize_labeled_span() {
 
     let span: LabeledSpan = serde_json::from_value(json!({
         "label": null,
-        "span": { "offset": 0, "length": 0 }
+        "span": { "offset": 0, "length": 0, },
+        "primary": false,
     }))
     .unwrap();
     assert_eq!(span, LabeledSpan::new(None, 0, 0));
 
     let span: LabeledSpan = serde_json::from_value(json!({
-        "span": { "offset": 0, "length": 0 }
+        "span": { "offset": 0, "length": 0, },
+        "primary": false 
     }))
     .unwrap();
     assert_eq!(span, LabeledSpan::new(None, 0, 0));
 
     let span: LabeledSpan = serde_json::from_value(json!({
         "label": "label",
-        "span": { "offset": 0, "length": 0 }
+        "span": { "offset": 0, "length": 0, },
+        "primary": false
     }))
     .unwrap();
     assert_eq!(span, LabeledSpan::new(Some("label".to_string()), 0, 0))

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -377,7 +377,7 @@ fn test_serialize_labeled_span() {
         json!({
             "label": "label",
             "span": { "offset": 0, "length": 0, },
-            "primary": false, 
+            "primary": false,
         })
     )
 }
@@ -397,7 +397,7 @@ fn test_deserialize_labeled_span() {
 
     let span: LabeledSpan = serde_json::from_value(json!({
         "span": { "offset": 0, "length": 0, },
-        "primary": false 
+        "primary": false
     }))
     .unwrap();
     assert_eq!(span, LabeledSpan::new(None, 0, 0));

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -86,7 +86,7 @@ fn single_line_highlight_span_full_line() {
     println!("Error: {}", out);
 
     let expected = r#"  × oops!
-   ╭─[issue:1:1]
+   ╭─[issue:2:1]
  1 │ source
  2 │ text
    · ──┬─
@@ -120,7 +120,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:7]
  1 │ source
  2 │   👼🏼text
    ·     ───┬──
@@ -159,7 +159,7 @@ fn single_line_with_two_tabs() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │         text
    ·         ──┬─
@@ -198,7 +198,7 @@ fn single_line_with_tab_in_middle() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:8]
  1 │ source
  2 │ text =  text
    ·         ──┬─
@@ -235,7 +235,7 @@ fn single_line_highlight() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬─
@@ -270,7 +270,7 @@ fn external_source() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬─
@@ -343,7 +343,7 @@ fn single_line_highlight_offset_end_of_line() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:1:7]
  1 │ source
    ·       ▲
    ·       ╰── this bit here
@@ -379,7 +379,7 @@ fn single_line_highlight_include_end_of_line() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬──
@@ -416,7 +416,7 @@ fn single_line_highlight_include_end_of_line_crlf() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬──
@@ -453,7 +453,7 @@ fn single_line_highlight_with_empty_span() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ▲
@@ -490,7 +490,7 @@ fn single_line_highlight_no_label() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ────
@@ -526,7 +526,7 @@ fn single_line_highlight_at_line_start() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:1]
  1 │ source
  2 │ text
    · ──┬─
@@ -569,7 +569,7 @@ fn multiple_same_line_highlights() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text text text text text
    ·   ──┬─ ──┬─      ──┬─
@@ -616,7 +616,7 @@ fn multiple_same_line_highlights_with_tabs_in_middle() -> Result<(), MietteError
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text text text    text text
    ·   ──┬─ ──┬─         ──┬─
@@ -655,7 +655,7 @@ fn multiline_highlight_adjacent() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │     source
  2 │ ╭─▶   text
  3 │ ├─▶     here
@@ -969,7 +969,7 @@ fn related() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬─
@@ -1031,7 +1031,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬─
@@ -1136,7 +1136,7 @@ fn related_severity() -> Result<(), MietteError> {
     let expected = r#"oops::my::bad
 
   × oops!
-   ╭─[bad_file.rs:1:1]
+   ╭─[bad_file.rs:2:3]
  1 │ source
  2 │   text
    ·   ──┬─
@@ -1201,7 +1201,7 @@ fn zero_length_eol_span() {
     println!("Error: {}", out);
 
     let expected = r#"  × oops!
-   ╭─[issue:1:1]
+   ╭─[issue:2:1]
  1 │ this is the first line
  2 │ this is the second line
    · ▲
@@ -1220,22 +1220,27 @@ fn primary_label() {
     struct MyBad {
         #[source_code]
         src: NamedSource,
-        #[primary_label("The root cause")]
-        bad_bit: SourceSpan,
+        #[label]
+        first_label: SourceSpan,
+        #[label(primary, "nope")]
+        second_label: SourceSpan,
     }
     let err = MyBad {
         src: NamedSource::new("issue", "this is the first line\nthis is the second line"),
-        bad_bit: (24, 4).into(),
+        first_label: (2, 4).into(),
+        second_label: (24, 4).into(),
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
 
+    // line 2 should be the primary, not line 1
     let expected = r#"  × oops!
    ╭─[issue:2:2]
  1 │ this is the first line
+   ·   ────
  2 │ this is the second line
    ·  ──┬─
-   ·    ╰── The root cause
+   ·    ╰── nope
    ╰────
 "#
     .to_string();

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1212,3 +1212,33 @@ fn zero_length_eol_span() {
 
     assert_eq!(expected, out);
 }
+
+#[test]
+fn primary_label() {
+    #[derive(Error, Debug, Diagnostic)]
+    #[error("oops!")]
+    struct MyBad {
+        #[source_code]
+        src: NamedSource,
+        #[primary_label("The root cause")]
+        bad_bit: SourceSpan,
+    }
+    let err = MyBad {
+        src: NamedSource::new("issue", "this is the first line\nthis is the second line"),
+        bad_bit: (24, 4).into(),
+    };
+    let out = fmt_report(err.into());
+    println!("Error: {}", out);
+
+    let expected = r#"  × oops!
+   ╭─[issue:2:2]
+ 1 │ this is the first line
+ 2 │ this is the second line
+   ·  ──┬─
+   ·    ╰── The root cause
+   ╰────
+"#
+    .to_string();
+
+    assert_eq!(expected, out);
+}

--- a/tests/test_diagnostic_source_macro.rs
+++ b/tests/test_diagnostic_source_macro.rs
@@ -91,7 +91,7 @@ fn test_diagnostic_source_pass_extra_info() {
     println!("Error: {}", out);
     let expected = r#"  × TestError
   ╰─▶   × A complex error happened
-         ╭─[1:1]
+         ╭─[1:2]
        1 │ Hello
          ·  ──┬─
          ·    ╰── here


### PR DESCRIPTION
As discussed in #91 and #208, it is sometimes desirable for the line/column numbers in a diagnostic to reference a label as opposed to the start of the context. However, there has to be a way of identifying which label to reference.

This PR implements one possible mechanism: a `label(primary)` attribute which acts just like `label`, except it marks a single label as being "primary". For example, this program:

```rust
use miette::{Diagnostic, SourceSpan};
use thiserror::Error;

#[derive(Error, Debug, Diagnostic)]
#[error("Primary span error")]
struct PrimarySpanError {
    #[source_code]
    src: String,
    #[label(primary)] // note the new attribute parameter
    span: SourceSpan,
}

fn main() -> miette::Result<()> {
    Err(PrimarySpanError {
        src: String::from("Hello\nworld"),
        span: (7..10).into(),
    }
    .into())
}
```

Produces this output:

```
Error:   × Primary span error
   ╭─[2:2]
 1 │ Hello
 2 │ world
   ·  ───
   ╰────
```

Note that the line/column info is `2:2` rather than `1:1` which you would get with a normal `#[label]`.

The core technical changes are:
* Adding a `primary: bool` field to `LabeledSpan`.
* Adding a method `LabeledSpan::new_primary_with_span` that constructs a `LabeledSpan` with `primary: true`.
* Extending the derive macro to support `label(primary)`.
* Modifying the `GraphicalHandler` to look for a primary label and use it if possible.
* Added a test to `graphical.rs` to check for this behavior.

These changes were specifically made to be fully backwards compatible.

This is my first time in the miette codebase, so I may have missed a code path. Let me know if I should change anything.