### PR TITLE
docs(README): Move import of `NamedResult` to where it is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can derive a `Diagnostic` from any `std::error::Error` type.
 
 `thiserror` is a great way to define them, and plays nicely with `miette`!
 */
-use miette::{Diagnostic, SourceSpan};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
 
 #[derive(Error, Debug, Diagnostic)]
@@ -123,7 +123,7 @@ Use this `Result` type (or its expanded version) as the return type
 throughout your app (but NOT your libraries! Those should always return
 concrete types!).
 */
-use miette::{NamedSource, Result};
+use miette::Result;
 fn this_fails() -> Result<()> {
     // You can use plain strings as a `Source`, or anything that implements
     // the one-method `Source` trait.


### PR DESCRIPTION
An example in README.md makes use of `miette::NamedResult` . It is imported in the second "example-step", but already used in the first one. Beginners, that copy the example step-by-step to understand it, will run into compile errors, as `NamedResult` was not imported.
