### PR TITLE
Expose additional `textwrap` options

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -56,6 +56,7 @@ pub struct MietteHandlerOpts {
     pub(crate) tab_width: Option<usize>,
     pub(crate) with_cause_chain: Option<bool>,
     pub(crate) break_words: Option<bool>,
+    pub(crate) word_separator: Option<textwrap::WordSeparator>,
 }
 
 impl MietteHandlerOpts {
@@ -94,6 +95,12 @@ impl MietteHandlerOpts {
     /// Defaults to true.
     pub fn break_words(mut self, break_words: bool) -> Self {
         self.break_words = Some(break_words);
+        self
+    }
+
+    /// Sets the `textwrap::WordSeparator` to use when determining wrap points.
+    pub fn word_separator(mut self, word_separator: textwrap::WordSeparator) -> Self {
+        self.word_separator = Some(word_separator);
         self
     }
 
@@ -247,6 +254,10 @@ impl MietteHandlerOpts {
             if let Some(b) = self.break_words {
                 handler = handler.with_break_words(b)
             }
+            if let Some(s) = self.word_separator {
+                handler = handler.with_word_separator(s)
+            }
+
             MietteHandler {
                 inner: Box::new(handler),
             }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -55,6 +55,7 @@ pub struct MietteHandlerOpts {
     pub(crate) context_lines: Option<usize>,
     pub(crate) tab_width: Option<usize>,
     pub(crate) with_cause_chain: Option<bool>,
+    pub(crate) break_words: Option<bool>,
 }
 
 impl MietteHandlerOpts {
@@ -83,6 +84,16 @@ impl MietteHandlerOpts {
     /// Sets the width to wrap the report at. Defaults to 80.
     pub fn width(mut self, width: usize) -> Self {
         self.width = Some(width);
+        self
+    }
+
+    /// If true, long words can be broken when wrapping.
+    ///
+    /// If false, long words will not be broken when they exceed the width.
+    ///
+    /// Defaults to true.
+    pub fn break_words(mut self, break_words: bool) -> Self {
+        self.break_words = Some(break_words);
         self
     }
 
@@ -232,6 +243,9 @@ impl MietteHandlerOpts {
             }
             if let Some(w) = self.tab_width {
                 handler = handler.tab_width(w);
+            }
+            if let Some(b) = self.break_words {
+                handler = handler.with_break_words(b)
             }
             MietteHandler {
                 inner: Box::new(handler),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -57,6 +57,7 @@ pub struct MietteHandlerOpts {
     pub(crate) with_cause_chain: Option<bool>,
     pub(crate) break_words: Option<bool>,
     pub(crate) word_separator: Option<textwrap::WordSeparator>,
+    pub(crate) word_splitter: Option<textwrap::WordSplitter>,
 }
 
 impl MietteHandlerOpts {
@@ -104,6 +105,11 @@ impl MietteHandlerOpts {
         self
     }
 
+    /// Sets the `textwrap::WordSplitter` to use when determining wrap points.
+    pub fn word_splitter(mut self, word_splitter: textwrap::WordSplitter) -> Self {
+        self.word_splitter = Some(word_splitter);
+        self
+    }
     /// Include the cause chain of the top-level error in the report.
     pub fn with_cause_chain(mut self) -> Self {
         self.with_cause_chain = Some(true);
@@ -256,6 +262,9 @@ impl MietteHandlerOpts {
             }
             if let Some(s) = self.word_separator {
                 handler = handler.with_word_separator(s)
+            }
+            if let Some(s) = self.word_splitter {
+                handler = handler.with_word_splitter(s)
             }
 
             MietteHandler {

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -32,6 +32,7 @@ pub struct GraphicalReportHandler {
     pub(crate) with_cause_chain: bool,
     pub(crate) break_words: bool,
     pub(crate) word_separator: Option<textwrap::WordSeparator>,
+    pub(crate) word_splitter: Option<textwrap::WordSplitter>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,6 +56,7 @@ impl GraphicalReportHandler {
             with_cause_chain: true,
             break_words: true,
             word_separator: None,
+            word_splitter: None,
         }
     }
 
@@ -70,6 +72,7 @@ impl GraphicalReportHandler {
             with_cause_chain: true,
             break_words: true,
             word_separator: None,
+            word_splitter: None,
         }
     }
 
@@ -134,9 +137,15 @@ impl GraphicalReportHandler {
         self
     }
 
-    /// Sets the word separator when wrapping.
+    /// Sets the word separator to use when wrapping.
     pub fn with_word_separator(mut self, word_separator: textwrap::WordSeparator) -> Self {
         self.word_separator = Some(word_separator);
+        self
+    }
+
+    /// Sets the word splitter to usewhen wrapping.
+    pub fn with_word_splitter(mut self, word_splitter: textwrap::WordSplitter) -> Self {
+        self.word_splitter = Some(word_splitter);
         self
     }
 
@@ -183,6 +192,9 @@ impl GraphicalReportHandler {
                 .break_words(self.break_words);
             if let Some(word_separator) = self.word_separator {
                 opts = opts.word_separator(word_separator);
+            }
+            if let Some(word_splitter) = self.word_splitter.clone() {
+                opts = opts.word_splitter(word_splitter);
             }
 
             writeln!(f, "{}", textwrap::fill(footer, opts))?;
@@ -242,6 +254,9 @@ impl GraphicalReportHandler {
         if let Some(word_separator) = self.word_separator {
             opts = opts.word_separator(word_separator);
         }
+        if let Some(word_splitter) = self.word_splitter.clone() {
+            opts = opts.word_splitter(word_splitter);
+        }
 
         writeln!(f, "{}", textwrap::fill(&diagnostic.to_string(), opts))?;
 
@@ -285,6 +300,9 @@ impl GraphicalReportHandler {
                 if let Some(word_separator) = self.word_separator {
                     opts = opts.word_separator(word_separator);
                 }
+                if let Some(word_splitter) = self.word_splitter.clone() {
+                    opts = opts.word_splitter(word_splitter);
+                }
 
                 match error {
                     ErrorKind::Diagnostic(diag) => {
@@ -318,6 +336,9 @@ impl GraphicalReportHandler {
                 .break_words(self.break_words);
             if let Some(word_separator) = self.word_separator {
                 opts = opts.word_separator(word_separator);
+            }
+            if let Some(word_splitter) = self.word_splitter.clone() {
+                opts = opts.word_splitter(word_splitter);
             }
 
             writeln!(f, "{}", textwrap::fill(&help.to_string(), opts))?;

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -30,6 +30,7 @@ pub struct GraphicalReportHandler {
     pub(crate) context_lines: usize,
     pub(crate) tab_width: usize,
     pub(crate) with_cause_chain: bool,
+    pub(crate) break_words: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,6 +52,7 @@ impl GraphicalReportHandler {
             context_lines: 1,
             tab_width: 4,
             with_cause_chain: true,
+            break_words: true,
         }
     }
 
@@ -64,6 +66,7 @@ impl GraphicalReportHandler {
             context_lines: 1,
             tab_width: 4,
             with_cause_chain: true,
+            break_words: true,
         }
     }
 
@@ -122,6 +125,12 @@ impl GraphicalReportHandler {
         self
     }
 
+    /// Enables or disables breaking of words during wrapping.
+    pub fn with_break_words(mut self, break_words: bool) -> Self {
+        self.break_words = break_words;
+        self
+    }
+
     /// Sets the 'global' footer for this handler.
     pub fn with_footer(mut self, footer: String) -> Self {
         self.footer = Some(footer);
@@ -161,7 +170,8 @@ impl GraphicalReportHandler {
             let width = self.termwidth.saturating_sub(4);
             let opts = textwrap::Options::new(width)
                 .initial_indent("  ")
-                .subsequent_indent("  ");
+                .subsequent_indent("  ")
+                .break_words(self.break_words);
             writeln!(f, "{}", textwrap::fill(footer, opts))?;
         }
         Ok(())
@@ -214,7 +224,8 @@ impl GraphicalReportHandler {
         let width = self.termwidth.saturating_sub(2);
         let opts = textwrap::Options::new(width)
             .initial_indent(&initial_indent)
-            .subsequent_indent(&rest_indent);
+            .subsequent_indent(&rest_indent)
+            .break_words(self.break_words);
 
         writeln!(f, "{}", textwrap::fill(&diagnostic.to_string(), opts))?;
 
@@ -253,7 +264,9 @@ impl GraphicalReportHandler {
                 .to_string();
                 let opts = textwrap::Options::new(width)
                     .initial_indent(&initial_indent)
-                    .subsequent_indent(&rest_indent);
+                    .subsequent_indent(&rest_indent)
+                    .break_words(self.break_words);
+
                 match error {
                     ErrorKind::Diagnostic(diag) => {
                         let mut inner = String::new();
@@ -282,7 +295,9 @@ impl GraphicalReportHandler {
             let initial_indent = "  help: ".style(self.theme.styles.help).to_string();
             let opts = textwrap::Options::new(width)
                 .initial_indent(&initial_indent)
-                .subsequent_indent("        ");
+                .subsequent_indent("        ")
+                .break_words(self.break_words);
+
             writeln!(f, "{}", textwrap::fill(&help.to_string(), opts))?;
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,6 +593,7 @@
 //!             .unicode(false)
 //!             .context_lines(3)
 //!             .tab_width(4)
+//!             .break_words(true)
 //!             .build(),
 //!     )
 //! }))

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -46,7 +46,7 @@ fn fmt_report_with_settings(
 
     handler.render_report(&mut out, diag.as_ref()).unwrap();
 
-    println!("Error:\n```\n{out}\n```");
+    println!("Error:\n```\n{}\n```", out);
 
     out
 }

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -34,6 +34,190 @@ fn fmt_report(diag: Report) -> String {
     out
 }
 
+fn fmt_report_with_settings(
+    diag: Report,
+    with_settings: fn(GraphicalReportHandler) -> GraphicalReportHandler,
+) -> String {
+    let mut out = String::new();
+
+    let handler = with_settings(GraphicalReportHandler::new_themed(
+        GraphicalTheme::unicode_nocolor(),
+    ));
+
+    handler.render_report(&mut out, diag.as_ref()).unwrap();
+
+    println!("Error:\n```\n{out}\n```");
+
+    out
+}
+
+#[test]
+fn word_wrap_options() -> Result<(), MietteError> {
+    // By default, a long word should not break
+    let out =
+        fmt_report_with_settings(Report::msg("abcdefghijklmnopqrstuvwxyz"), |handler| handler);
+
+    let expected = "  × abcdefghijklmnopqrstuvwxyz\n".to_string();
+    assert_eq!(expected, out);
+
+    // A long word can break with a smaller width
+    let out = fmt_report_with_settings(Report::msg("abcdefghijklmnopqrstuvwxyz"), |handler| {
+        handler.with_width(10)
+    });
+    let expected = r#"  × abcd
+  │ efgh
+  │ ijkl
+  │ mnop
+  │ qrst
+  │ uvwx
+  │ yz
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    // Unless, word breaking is disabled
+    let out = fmt_report_with_settings(Report::msg("abcdefghijklmnopqrstuvwxyz"), |handler| {
+        handler.with_width(10).with_break_words(false)
+    });
+    let expected = "  × abcdefghijklmnopqrstuvwxyz\n".to_string();
+    assert_eq!(expected, out);
+
+    // Breaks should start at the boundary of each word if possible
+    let out = fmt_report_with_settings(
+        Report::msg("12 123 1234 12345 123456 1234567 1234567890"),
+        |handler| handler.with_width(10),
+    );
+    let expected = r#"  × 12
+  │ 123
+  │ 1234
+  │ 1234
+  │ 5
+  │ 1234
+  │ 56
+  │ 1234
+  │ 567
+  │ 1234
+  │ 5678
+  │ 90
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    // But long words should not break if word breaking is disabled
+    let out = fmt_report_with_settings(
+        Report::msg("12 123 1234 12345 123456 1234567 1234567890"),
+        |handler| handler.with_width(10).with_break_words(false),
+    );
+    let expected = r#"  × 12
+  │ 123
+  │ 1234
+  │ 12345
+  │ 123456
+  │ 1234567
+  │ 1234567890
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    // Unless, of course, there are hyphens
+    let out = fmt_report_with_settings(
+        Report::msg("a-b a-b-c a-b-c-d a-b-c-d-e a-b-c-d-e-f a-b-c-d-e-f-g a-b-c-d-e-f-g-h"),
+        |handler| handler.with_width(10).with_break_words(false),
+    );
+    let expected = r#"  × a-b
+  │ a-b-
+  │ c a-
+  │ b-c-
+  │ d a-
+  │ b-c-
+  │ d-e
+  │ a-b-
+  │ c-d-
+  │ e-f
+  │ a-b-
+  │ c-d-
+  │ e-f-
+  │ g a-
+  │ b-c-
+  │ d-e-
+  │ f-g-
+  │ h
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    // Which requires an additional opt-out
+    let out = fmt_report_with_settings(
+        Report::msg("a-b a-b-c a-b-c-d a-b-c-d-e a-b-c-d-e-f a-b-c-d-e-f-g a-b-c-d-e-f-g-h"),
+        |handler| {
+            handler
+                .with_width(10)
+                .with_break_words(false)
+                .with_word_splitter(textwrap::WordSplitter::NoHyphenation)
+        },
+    );
+    let expected = r#"  × a-b
+  │ a-b-c
+  │ a-b-c-d
+  │ a-b-c-d-e
+  │ a-b-c-d-e-f
+  │ a-b-c-d-e-f-g
+  │ a-b-c-d-e-f-g-h
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    // Or if there are _other_ unicode word boundaries
+    let out = fmt_report_with_settings(
+        Report::msg("a/b a/b/c a/b/c/d a/b/c/d/e a/b/c/d/e/f a/b/c/d/e/f/g a/b/c/d/e/f/g/h"),
+        |handler| handler.with_width(10).with_break_words(false),
+    );
+    let expected = r#"  × a/b
+  │ a/b/
+  │ c a/
+  │ b/c/
+  │ d a/
+  │ b/c/
+  │ d/e
+  │ a/b/
+  │ c/d/
+  │ e/f
+  │ a/b/
+  │ c/d/
+  │ e/f/
+  │ g a/
+  │ b/c/
+  │ d/e/
+  │ f/g/
+  │ h
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    // Such things require you to opt-in to only breaking on ASCII whitespace
+    let out = fmt_report_with_settings(
+        Report::msg("a/b a/b/c a/b/c/d a/b/c/d/e a/b/c/d/e/f a/b/c/d/e/f/g a/b/c/d/e/f/g/h"),
+        |handler| {
+            handler
+                .with_width(10)
+                .with_break_words(false)
+                .with_word_separator(textwrap::WordSeparator::AsciiSpace)
+        },
+    );
+    let expected = r#"  × a/b
+  │ a/b/c
+  │ a/b/c/d
+  │ a/b/c/d/e
+  │ a/b/c/d/e/f
+  │ a/b/c/d/e/f/g
+  │ a/b/c/d/e/f/g/h
+"#
+    .to_string();
+    assert_eq!(expected, out);
+
+    Ok(())
+}
+
 #[test]
 fn empty_source() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]


### PR DESCRIPTION
Hi!

Thanks for the project, it's really nice.

I'm running into problems when my report has a URL in it — it's wrapping to the next line on `/` boundaries. This is both a cosmetic problem and a functional one as the link cannot be clicked.

```rust
fn main() {
    let url = "https://files.pythonhosted.org/packages/bd/24/11c3ea5a7e866bf2d97f0501d0b4b1c9bbeade102bb4b588f0d2919a5212/Werkzeug-2.0.1-py3-none-any.whl";
    let report = miette::Report::msg(format!("There was a failure with {url}")).context("Oh no");

    eprint!("{report:?}");
}
```
```
  × Oh no
  ╰─▶ There was a failure with https://files.pythonhosted.org/packages/
      bd/24/11c3ea5a7e866bf2d97f0501d0b4b1c9bbeade102bb4b588f0d2919a5212/Werkzeug-2.0.1-py3-none-any.whl
```

After some digging, I discovered this behavior is due to defaults in `textwrap` and that there was not a way to change them without reimplementing the default graphical handler which seemed relatively unpleasant to maintain. Instead, I added three new options to `MietteHandlerOpts` that are passed through to `textwrap`:

- `break_words`: to disable breaking of long words when wrapping text
- `word_separator`: to allow customization of what is considered a word when wrapping text
- `word_splitter`: to allow customization of splitting words when wrapping text

 Then, the miette handler can then be configured as follows:

```rust
miette::set_hook(Box::new(|_| {
    Box::new(
        miette::MietteHandlerOpts::new()
            .break_words(false)
            .word_separator(textwrap::WordSeparator::AsciiSpace)
            .word_splitter(textwrap::WordSplitter::NoHyphenation)
            .build(),
    )
}))?;
```

```
  × Oh no
  ╰─▶ There was a failure with
      https://files.pythonhosted.org/packages/bd/24/11c3ea5a7e866bf2d97f0501d0b4b1c9bbeade102bb4b588f0d2919a5212/Werkzeug-2.0.1-py3-none-any.whl
```

I also considered a `text_wrap_options` setting to just wrap all of the supported text wrap options. We'd still need to take `width` separately and this seemed a bit heavier so I didn't implement it here. However, it seems marginally more maintainable than adding individual settings for each text wrap option people need.

I was surprised not to see any other complaints about the default wrapping behavior — let me know if I missed anything. If you'd prefer to discuss this in an issue first, just let me know.

~I did not add test cases yet because I'm a little uncertain of the intent of your test setup. I'm happy to do so though :)~

Related:

- `rustfmt` relaxed their line wrapping to avoid breaking URLs (https://github.com/rust-lang/rustfmt/pull/911)
- https://github.com/mgeisler/textwrap/issues/384
