### PR TITLE
Clean up render snippets

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -405,16 +405,12 @@ impl GraphicalReportHandler {
                 // The snippets will overlap, so we create one Big Chunky Boi
                 let left_end = left.offset() + left.len();
                 let right_end = right.offset() + right.len();
+                let new_end = std::cmp::max(left_end, right_end);
+
                 let new_span = LabeledSpan::new(
                     left.label().map(String::from),
                     left.offset(),
-                    if right_end >= left_end {
-                        // Right end goes past left end
-                        right_end - left.offset()
-                    } else {
-                        // right is contained inside left
-                        left.len()
-                    },
+                    new_end - left.offset(),
                 );
                 // Check that the two contexts can be combined
                 if let Ok(new_conts) =

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -446,10 +446,16 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         let (contents, lines) = self.get_lines(source, context.inner())?;
 
-        let primary_label = labels
-            .iter()
+        // only consider labels from the context as primary label
+        let ctx_labels = labels.iter().filter(|l| {
+            context.inner().offset() <= l.inner().offset()
+                && l.inner().offset() + l.inner().len()
+                    <= context.inner().offset() + context.inner().len()
+        });
+        let primary_label = ctx_labels
+            .clone()
             .find(|label| label.primary())
-            .or_else(|| labels.first());
+            .or_else(|| ctx_labels.clone().next());
 
         // sorting is your friend
         let labels = labels

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1730,12 +1730,12 @@ fn triple_adjacent_highlight() -> Result<(), MietteError> {
         highlight3: SourceSpan,
     }
 
-    let src = "source\n  text\n    here".to_string();
+    let src = "source\n\n\n  text\n\n\n    here".to_string();
     let err = MyBad {
         src: NamedSource::new("bad_file.rs", src),
         highlight1: (0, 6).into(),
-        highlight2: (9, 4).into(),
-        highlight3: (18, 4).into(),
+        highlight2: (11, 4).into(),
+        highlight3: (22, 4).into(),
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
@@ -1746,17 +1746,19 @@ fn triple_adjacent_highlight() -> Result<(), MietteError> {
  1 │ source
    · ───┬──
    ·    ╰── this bit here
- 2 │   text
+ 2 │ 
+ 3 │ 
+ 4 │   text
    ·   ──┬─
    ·     ╰── also this bit
- 3 │     here
+ 5 │ 
+ 6 │ 
+ 7 │     here
    ·     ──┬─
    ·       ╰── finally we got
    ╰────
   help: try doing it better next time?
-"
-    .trim_start()
-    .to_string();
-    assert_eq!(expected, out);
+";
+    assert_eq!(expected, &out);
     Ok(())
 }

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1762,3 +1762,46 @@ fn triple_adjacent_highlight() -> Result<(), MietteError> {
     assert_eq!(expected, &out);
     Ok(())
 }
+
+#[test]
+fn non_adjacent_highlight() -> Result<(), MietteError> {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("oops!")]
+    #[diagnostic(code(oops::my::bad), help("try doing it better next time?"))]
+    struct MyBad {
+        #[source_code]
+        src: NamedSource,
+        #[label = "this bit here"]
+        highlight1: SourceSpan,
+        #[label = "also this bit"]
+        highlight2: SourceSpan,
+    }
+
+    let src = "source\n\n\n\n  text    here".to_string();
+    let err = MyBad {
+        src: NamedSource::new("bad_file.rs", src),
+        highlight1: (0, 6).into(),
+        highlight2: (12, 4).into(),
+    };
+    let out = fmt_report(err.into());
+    println!("Error: {}", out);
+    let expected = "oops::my::bad
+
+  × oops!
+   ╭─[bad_file.rs:1:1]
+ 1 │ source
+   · ───┬──
+   ·    ╰── this bit here
+ 2 │ 
+   ╰────
+   ╭─[bad_file.rs:5:3]
+ 4 │ 
+ 5 │   text    here
+   ·   ──┬─
+   ·     ╰── also this bit
+   ╰────
+  help: try doing it better next time?
+";
+    assert_eq!(expected, &out);
+    Ok(())
+}


### PR DESCRIPTION
Hey, here are some local changes I made that might be useful.

In the first commit I tried to make the `render_snippets` function more readable and fixed what I think was a bug.
(Looks like it would not merge more than two contexts if the last context didn't overlap the first)

In the second commit I restricted finding the primary label to those in the current context.
This makes it so that the header above each snippet points to code in the snippet.
(It is especially useful for `SourceCode` implementations that wrap multiple files)

Example showing different headers for different snippets:
![image](https://github.com/zkat/miette/assets/24637999/20017e9b-0970-40f4-8e0e-3342af743932)
