### PR TITLE
fix(handler): remove the two extra `is_terminal` sys call from `MietteHandlerOpts::build`

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -237,10 +237,9 @@ impl MietteHandlerOpts {
                 ThemeStyles::none()
             };
             let theme = self.theme.unwrap_or(GraphicalTheme { characters, styles });
-            let mut handler = GraphicalReportHandler::new()
+            let mut handler = GraphicalReportHandler::new_themed(theme)
                 .with_width(width)
-                .with_links(linkify)
-                .with_theme(theme);
+                .with_links(linkify);
             if let Some(with_cause_chain) = self.with_cause_chain {
                 if with_cause_chain {
                     handler = handler.with_cause_chain();


### PR DESCRIPTION
`GraphicalReportHandler::new()` calls `GraphicalTheme::default()`

https://github.com/zkat/miette/blob/7ff4f874d693a665af4df40f4e94505013e3e262/src/handlers/graphical.rs#L52

which calls `std::io::stdout().is_terminal()` and `std::io::stderr().is_terminal()`

https://github.com/zkat/miette/blob/7ff4f874d693a665af4df40f4e94505013e3e262/src/handlers/theme.rs#L72

but this default theme is overridden by `with_theme(theme)`.