### PR TITLE
fix(handler): do not call `supports_color::on` when color is forced

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -222,15 +222,15 @@ impl MietteHandlerOpts {
             };
             let styles = if self.color == Some(false) {
                 ThemeStyles::none()
+            } else if self.color == Some(true) {
+                match self.rgb_colors {
+                    RgbColors::Always => ThemeStyles::rgb(),
+                    _ => ThemeStyles::ansi(),
+                }
             } else if let Some(color) = supports_color::on(supports_color::Stream::Stderr) {
                 match self.rgb_colors {
                     RgbColors::Always => ThemeStyles::rgb(),
                     RgbColors::Preferred if color.has_16m => ThemeStyles::rgb(),
-                    _ => ThemeStyles::ansi(),
-                }
-            } else if self.color == Some(true) {
-                match self.rgb_colors {
-                    RgbColors::Always => ThemeStyles::rgb(),
                     _ => ThemeStyles::ansi(),
                 }
             } else {


### PR DESCRIPTION
This reduces a sys call when color is forced.

I'm not sure whether the logic after the change is correct or not, but the documentation seems to support it?

https://docs.rs/miette/latest/miette/struct.MietteHandlerOpts.html#method.color

> If true, colors will be used during graphical rendering, regardless of whether or not the terminal supports them.
>
> If false, colors will never be used.
>
> If unspecified, colors will be used only if the terminal supports them.