### PR TITLE
feat(fancy): Add option to change the link display texts

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -36,6 +36,7 @@ pub struct GraphicalReportHandler {
     pub(crate) word_separator: Option<textwrap::WordSeparator>,
     pub(crate) word_splitter: Option<textwrap::WordSplitter>,
     pub(crate) highlighter: MietteHighlighter,
+    pub(crate) link_display_text: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +63,7 @@ impl GraphicalReportHandler {
             word_separator: None,
             word_splitter: None,
             highlighter: MietteHighlighter::default(),
+            link_display_text: None,
         }
     }
 
@@ -80,6 +82,7 @@ impl GraphicalReportHandler {
             word_separator: None,
             word_splitter: None,
             highlighter: MietteHighlighter::default(),
+            link_display_text: None,
         }
     }
 
@@ -190,6 +193,13 @@ impl GraphicalReportHandler {
         self.highlighter = MietteHighlighter::nocolor();
         self
     }
+
+    /// Sets the display text for links.
+    /// Miette displays `(link)` if this option is not set.
+    pub fn with_link_display_text(mut self, text: impl Into<String>) -> Self {
+        self.link_display_text = Some(text.into());
+        self
+    }
 }
 
 impl Default for GraphicalReportHandler {
@@ -246,11 +256,12 @@ impl GraphicalReportHandler {
             } else {
                 "".to_string()
             };
+            let display_text = self.link_display_text.as_deref().unwrap_or("(link)");
             let link = format!(
                 "\u{1b}]8;;{}\u{1b}\\{}{}\u{1b}]8;;\u{1b}\\",
                 url,
                 code.style(severity_style),
-                "(link)".style(self.theme.styles.link)
+                display_text.style(self.theme.styles.link)
             );
             write!(header, "{}", link)?;
             writeln!(f, "{}", header)?;

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1342,6 +1342,28 @@ fn disable_url_links() -> Result<(), MietteError> {
 }
 
 #[test]
+fn url_links_with_display_text() -> Result<(), MietteError> {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("oops!")]
+    #[diagnostic(
+        code(oops::my::bad),
+        help("try doing it better next time?"),
+        url("https://example.com")
+    )]
+    struct MyBad;
+    let err = MyBad;
+    let out = fmt_report_with_settings(err.into(), |handler| {
+        handler.with_link_display_text("Read the documentation")
+    });
+
+    println!("Error: {}", out);
+    assert!(out.contains("https://example.com"));
+    assert!(out.contains("Read the documentation"));
+    assert!(out.contains("oops::my::bad"));
+    Ok(())
+}
+
+#[test]
 fn related() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]


### PR DESCRIPTION
This option allows to globally change the default `(link)` display text with any other text provider by users.

I investigated if it was possible to change the display text per error, but I was not sold of any option I tried. I think this is a pretty simple addition that can help people like me that just want to change this text for all the errors.

Fixes #331 