### PR TITLE
feat(derive): enable more boxed types to be #[diagnostic_source]

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -69,7 +69,7 @@ pub trait Diagnostic: std::error::Error {
     }
 }
 
-macro_rules! box_impls {
+macro_rules! box_error_impls {
     ($($box_type:ty),*) => {
         $(
             impl std::error::Error for $box_type {
@@ -85,8 +85,25 @@ macro_rules! box_impls {
     }
 }
 
-box_impls! {
+box_error_impls! {
     Box<dyn Diagnostic>,
+    Box<dyn Diagnostic + Send>,
+    Box<dyn Diagnostic + Send + Sync>
+}
+
+macro_rules! box_borrow_impls {
+    ($($box_type:ty),*) => {
+        $(
+            impl std::borrow::Borrow<dyn Diagnostic> for $box_type {
+                fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+                    self.as_ref()
+                }
+            }
+        )*
+    }
+}
+
+box_borrow_impls! {
     Box<dyn Diagnostic + Send>,
     Box<dyn Diagnostic + Send + Sync>
 }

--- a/tests/test_diagnostic_source_macro.rs
+++ b/tests/test_diagnostic_source_macro.rs
@@ -43,6 +43,14 @@ struct TestBoxedError(#[diagnostic_source] Box<dyn Diagnostic>);
 
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
 #[error("TestError")]
+struct TestBoxedSendError(#[diagnostic_source] Box<dyn Diagnostic + Send>);
+
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("TestError")]
+struct TestBoxedSendSyncError(#[diagnostic_source] Box<dyn Diagnostic + Send + Sync>);
+
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("TestError")]
 struct TestArcedError(#[diagnostic_source] std::sync::Arc<dyn Diagnostic>);
 
 #[test]
@@ -69,6 +77,12 @@ fn test_diagnostic_source() {
     assert!(error.diagnostic_source().is_some());
 
     let error = TestBoxedError(Box::new(AnErr));
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestBoxedSendError(Box::new(AnErr));
+    assert!(error.diagnostic_source().is_some());
+
+    let error = TestBoxedSendSyncError(Box::new(AnErr));
     assert!(error.diagnostic_source().is_some());
 
     let error = TestArcedError(std::sync::Arc::new(AnErr));


### PR DESCRIPTION
Hello again! Nice and small change this time :)

The `#[diagnostic_source]` attribute already worked for `Box<dyn Diagnostic>`, but not for the highly-related `Box<dyn Diagnostic + Send>` and `Box<dyn Diagnostic + Send + Sync>` types!

It looks like someone already solved this issue for `std::error:Error` with a `macro_rules!` implementation, so I've done the same here to let those new cases compile! Without those `Borrow<dyn Diagnostic>` impls, you end up with compiler errors coming from inside of the derive macro:

![Screenshot from 2024-02-06 20-26-45](https://github.com/zkat/miette/assets/6251883/10fb0847-dd6d-4e03-957f-f7685ed13afe)

Let me know if you have any questions! I'll separately try to sort out those failing tests (unrelated to this change) in another PR :)
