### PR TITLE
fix(tests): revert test-breaking changes of e5c7ae4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           toolchain: nightly
       - name: Run minimal version build
-        run: cargo build -Z minimal-versions --features fancy,no-format-args-capture
+        run: cargo build -Z direct-minimal-versions --features fancy,no-format-args-capture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures = { version = "0.3", default-features = false }
 indenter = "0.3.3"
 rustversion = "1.0"
 trybuild = { version = "1.0.89", features = ["diff"] }
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0.48", features = ["full"] }
 regex = "1.10"
 lazy_static = "1.4"
 

--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -12,5 +12,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.78"
-quote = "1.0"
+quote = "1.0.35"
 syn = "2.0.48"

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1864,11 +1864,11 @@ fn syntax_highlighter_on_real_file() {
     let expected = format!(
         r#"  × This is an error
       ╭─[{filename}:{l2}:{CO}]
- {l1} │
+ {l1} │ 
  {l2} │     let (filename, line) = (file!(), line!() as usize);
       ·                            ─────────────┬─────────────
       ·                                         ╰── this is a label
- {l3} │
+ {l3} │ 
       ╰────
 "#,
         l1 = line - 1,
@@ -1911,13 +1911,13 @@ fn triple_adjacent_highlight() -> Result<(), MietteError> {
  1 │ source
    · ───┬──
    ·    ╰── this bit here
- 2 │
- 3 │
+ 2 │ 
+ 3 │ 
  4 │   text
    ·   ──┬─
    ·     ╰── also this bit
- 5 │
- 6 │
+ 5 │ 
+ 6 │ 
  7 │     here
    ·     ──┬─
    ·       ╰── finally we got
@@ -1957,10 +1957,10 @@ fn non_adjacent_highlight() -> Result<(), MietteError> {
  1 │ source
    · ───┬──
    ·    ╰── this bit here
- 2 │
+ 2 │ 
    ╰────
    ╭─[bad_file.rs:5:3]
- 4 │
+ 4 │ 
  5 │   text    here
    ·   ──┬─
    ·     ╰── also this bit


### PR DESCRIPTION
The commit e5c7ae4 seemed to (potentially erronously?) remove a number of spaces following the left `|` bar of some graphical report handler tests. That change had no effect on the `syntax_highlighter_on_real_file()` test, presumably because the trailing whitespace is removed by `strip_ansi_escapes::strip_str()`, but it did break the `triple_adjacent_highlight()` and `non_adjacent_hightlight()` tests. Restoring the spaces removed in e5c7ae4 fixes the failing tests on main.