### PR TITLE
feat(source): derive common traits for NamedSource, SourceSpan, and SourceOffset

### DIFF
--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -3,6 +3,7 @@ use crate::{MietteError, MietteSpanContents, SourceCode, SpanContents};
 /// Utility struct for when you have a regular [`SourceCode`] type that doesn't
 /// implement `name`. For example [`String`]. Or if you want to override the
 /// `name` returned by the `SourceCode`.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NamedSource<S: SourceCode + 'static> {
     source: S,
     name: String,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -550,7 +550,7 @@ impl<'a> SpanContents<'a> for MietteSpanContents<'a> {
 }
 
 /// Span within a [`SourceCode`]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SourceSpan {
     /// The start of the span.
@@ -652,7 +652,7 @@ pub type ByteOffset = usize;
 /**
 Newtype that represents the [`ByteOffset`] from the beginning of a [`SourceCode`]
 */
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SourceOffset(ByteOffset);
 


### PR DESCRIPTION
One-liner sanding off a small rough edge I came across: using `NamedSource<String>` (instead of simply `String`) severely limits which traits can be derived for the wrapping diagnostic. In my case, I lost the ability to clone my error!

![image](https://github.com/zkat/miette/assets/6251883/8261e3f2-bfc8-4690-b102-af76b318e281)

I've brought things in line with https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits, leaving out `Copy`, `Display`, and `Default`, since those derives are either not possible or don't feel useful. The ones I've added here make sure people can `.clone()` errors, compare them, sort them, and use them in `HashSet`s / `HashMap`s.

I also added `Ord` derives to the `SourceSpan` and `SourceOffset` types for the same reason!