### PR TITLE
Label collection fixes and cleanup

### DIFF
--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -197,7 +197,7 @@ impl Labels {
             let Label {
                 span,
                 label,
-                ty,
+                ty: _,
                 lbl_ty,
             } = label;
             if *lbl_ty != LabelType::Collection {
@@ -212,16 +212,13 @@ impl Labels {
             Some(quote! {
                 .chain({
                     let display = #display;
-                    self.#span.iter().map(move |label| {
-                        miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(label)
-                            .map(|span| {
-                                use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
-                                let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
-                                if display.is_some() && labeled_span.label().is_none() {
-                                    labeled_span.set_label(display.clone())
-                                }
-                                labeled_span
-                            })
+                    self.#span.iter().map(move |span| {
+                        use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
+                        let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
+                        if display.is_some() && labeled_span.label().is_none() {
+                            labeled_span.set_label(display.clone())
+                        }
+                        Some(labeled_span)
                     })
                 })
             })
@@ -284,7 +281,7 @@ impl Labels {
                         })
                     });
                     let collections_chain = labels.0.iter().filter_map(|label| {
-                        let Label { span, label, ty, lbl_ty } = label;
+                        let Label { span, label, ty: _, lbl_ty } = label;
                         if *lbl_ty != LabelType::Collection {
                             return None;
                         }
@@ -303,16 +300,13 @@ impl Labels {
                         Some(quote! {
                             .chain({
                                 let display = #display;
-                                #field.iter().map(move |label| {
-                                    miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(label)
-                                        .map(|span| {
-                                            use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
-                                            let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
-                                            if display.is_some() && labeled_span.label().is_none() {
-                                                labeled_span.set_label(display.clone());
-                                            }
-                                            labeled_span
-                                        })
+                                #field.iter().map(move |span| {
+                                    use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
+                                    let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
+                                    if display.is_some() && labeled_span.label().is_none() {
+                                        labeled_span.set_label(display.clone());
+                                    }
+                                    Some(labeled_span)
                                 })
                             })
                         })

--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -217,8 +217,8 @@ impl Labels {
                         .map(|span| {
                             use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
                             let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
-                            if #display.is_some() && labeled_span.label().is_none() {
-                                labeled_span.set_label(#display)
+                            if display.is_some() && labeled_span.label().is_none() {
+                                labeled_span.set_label(display.clone())
                             }
                             labeled_span
                         })
@@ -306,8 +306,8 @@ impl Labels {
                                     .map(|span| {
                                         use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
                                         let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
-                                        if #display.is_some() && labeled_span.label().is_none() {
-                                            labeled_span.set_label(#display)
+                                        if display.is_some() && labeled_span.label().is_none() {
+                                            labeled_span.set_label(display.clone())
                                         }
                                         labeled_span
                                     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 //!   - [... handler options](#-handler-options)
 //!   - [... dynamic diagnostics](#-dynamic-diagnostics)
 //!   - [... syntax highlighting](#-syntax-highlighting)
+//!   - [... collection of labels](#-collection-of-labels)
 //! - [Acknowledgements](#acknowledgements)
 //! - [License](#license)
 //!
@@ -671,6 +672,57 @@
 //! trait to [`MietteHandlerOpts`] by calling the
 //! [`with_syntax_highlighting`](MietteHandlerOpts::with_syntax_highlighting)
 //! method. See the [`highlighters`] module docs for more details.
+//!
+//! ### ... collection of labels
+//!
+//! When the number of labels is unknown, you can use a collection of `SourceSpan`
+//! (or any type convertible into `SourceSpan`). For this, add the `collection`
+//! parameter to `label` and use any type than can be iterated over for the field.
+//!
+//! ```rust,ignore
+//! #[derive(Debug, Diagnostic, Error)]
+//! #[error("oops!")]
+//! struct MyError {
+//!     #[label("main issue")]
+//!     primary_span: SourceSpan,
+//!
+//!     #[label(collection, "related to this")]
+//!     other_spans: Vec<Range<usize>>,
+//! }
+//!
+//! let report: miette::Report = MyError {
+//!     primary_span: (6, 9).into(),
+//!     other_spans: vec![19..26, 30..41],
+//! }.into();
+//!
+//! println!("{:?}", report.with_source_code("About something or another or yet another ...".to_string()));
+//! ```
+//!
+//! A collection can also be of `LabeledSpan` if you want to have different text
+//! for different labels. Labels with no text will use the one from the `label`
+//! attribute
+//!
+//! ```rust,ignore
+//! #[derive(Debug, Diagnostic, Error)]
+//! #[error("oops!")]
+//! struct MyError {
+//!     #[label("main issue")]
+//!     primary_span: SourceSpan,
+//!
+//!     #[label(collection, "related to this")]
+//!     other_spans: Vec<LabeledSpan>, // LabeledSpan
+//! }
+//!
+//! let report: miette::Report = MyError {
+//!     primary_span: (6, 9).into(),
+//!     other_spans: vec![
+//!         LabeledSpan::new(None, 19, 7), // Use default text `related to this`
+//!         LabeledSpan::new(Some("and also this".to_string()), 30, 11), // Use specific text
+//!     ],
+//! }.into();
+//!
+//! println!("{:?}", report.with_source_code("About something or another or yet another ...".to_string()));
+//! ```
 //!
 //! ## MSRV
 //!


### PR DESCRIPTION
The most important one is adding the documentation to lib.rs. I didn't know the documentation was there and the README.md was built out of it.

The rest is removing pointless or redundant code.

(The change about chaining the iterators started from a compilation warning about an unnecessarily mutable variable. However
I'm not sure how I was getting that warning, I cannot reproduce it anymore. But I think the change it still worthwhile anyway, but
opinions may vary :))