### PR TITLE
fix(invalid span): skip the snippet when read_span fails

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -436,9 +436,25 @@ impl GraphicalReportHandler {
 
         let mut contexts = Vec::with_capacity(labels.len());
         for right in labels.iter().cloned() {
-            let right_conts = source
-                .read_span(right.inner(), self.context_lines, self.context_lines)
-                .map_err(|_| fmt::Error)?;
+            let right_conts =
+                match source.read_span(right.inner(), self.context_lines, self.context_lines) {
+                    Ok(cont) => cont,
+                    Err(err) => {
+                        writeln!(
+                            f,
+                            "  [{} `{}` (offset: {}, length: {}): {:?}]",
+                            "Failed to read contents for label".style(self.theme.styles.error),
+                            right
+                                .label()
+                                .unwrap_or("<none>")
+                                .style(self.theme.styles.link),
+                            right.offset().style(self.theme.styles.link),
+                            right.len().style(self.theme.styles.link),
+                            err.style(self.theme.styles.warning)
+                        )?;
+                        return Ok(());
+                    }
+                };
 
             if contexts.is_empty() {
                 contexts.push((right, right_conts));


### PR DESCRIPTION
Fixes: https://github.com/zkat/miette/issues/219

When a snippet couldn't be read (typically because the span didn't fit within the source code), it and the rest of the diagnostic were silently dropped, which was confusing to the developer.
Now, in place of the snippet, print an error message with the name of the failed label and the error it triggered, then proceed with the rest of the diagnostic (footer, related, ...)


This is what it looks like:
![image](https://github.com/zkat/miette/assets/1198364/61c5ce14-ba05-43dc-abc3-0ed1a6ed2d0b)
