### PR TITLE
feat: add feature "fancy-no-syscall" for wasm targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,19 @@ jobs:
         if: matrix.rust == '1.70.0'
         run: cargo test --all --verbose --features ${{matrix.features}} no-format-args-capture
 
+  wasm:
+    name: Check Wasm build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - name: Check wasm target
+        run: cargo check --target wasm32-unknown-unknown --features fancy
+
   miri:
     name: Miri
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - name: Check wasm target
-        run: cargo check --target wasm32-unknown-unknown --features fancy
+        run: cargo check --target wasm32-unknown-unknown --features fancy-no-syscall
 
   miri:
     name: Miri
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests with miri
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
-        run: cargo miri test --all --verbose --features fancy
+        run: cargo miri test --all --verbose --features fancy-no-syscall
 
   minimal_versions:
     name: Minimal versions check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests with miri
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
-        run: cargo miri test --all --verbose --features fancy-no-syscall
+        run: cargo miri test --all --verbose
 
   minimal_versions:
     name: Minimal versions check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests with miri
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
-        run: cargo miri test --all --verbose
+        run: cargo miri test --all --verbose --features fancy
 
   minimal_versions:
     name: Minimal versions check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["images/", "tests/", "miette-derive/"]
 thiserror = "1.0.56"
 miette-derive = { path = "miette-derive", version = "=7.1.0", optional = true }
 unicode-width = "0.1.11"
+cfg-if = "1.0.0"
 
 owo-colors = { version = "4.0.0", optional = true }
 textwrap = { version = "0.16.0", optional = true }
@@ -47,6 +48,10 @@ strip-ansi-escapes = "0.2.0"
 default = ["derive"]
 derive = ["miette-derive"]
 no-format-args-capture = []
+fancy-no-syscall = [
+    "owo-colors",
+    "textwrap",
+]
 fancy-no-backtrace = [
     "owo-colors",
     "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,16 +48,15 @@ strip-ansi-escapes = "0.2.0"
 default = ["derive"]
 derive = ["miette-derive"]
 no-format-args-capture = []
-fancy-base = []
-fancy-no-syscall = [
-    "fancy-base",
+fancy-base = [
     "owo-colors",
     "textwrap",
 ]
+fancy-no-syscall = [
+    "fancy-base",
+]
 fancy-no-backtrace = [
     "fancy-base",
-    "owo-colors",
-    "textwrap",
     "terminal_size",
     "supports-hyperlinks",
     "supports-color",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,16 @@ strip-ansi-escapes = "0.2.0"
 default = ["derive"]
 derive = ["miette-derive"]
 no-format-args-capture = []
+fancy-base = []
 fancy-no-syscall = [
+    "fancy-base",
     "owo-colors",
     "textwrap",
 ]
 fancy-no-backtrace = [
-    "fancy-no-syscall",
+    "fancy-base",
+    "owo-colors",
+    "textwrap",
     "terminal_size",
     "supports-hyperlinks",
     "supports-color",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,7 @@ fancy-no-syscall = [
     "textwrap",
 ]
 fancy-no-backtrace = [
-    "owo-colors",
-    "textwrap",
+    "fancy-no-syscall",
     "terminal_size",
     "supports-hyperlinks",
     "supports-color",

--- a/src/eyreish/mod.rs
+++ b/src/eyreish/mod.rs
@@ -24,10 +24,10 @@ pub use ReportHandler as EyreContext;
 #[allow(unreachable_pub)]
 pub use WrapErr as Context;
 
-#[cfg(not(feature = "fancy-no-backtrace"))]
+#[cfg(not(feature = "fancy-no-syscall"))]
 use crate::DebugReportHandler;
 use crate::Diagnostic;
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 use crate::MietteHandler;
 
 use error::ErrorImpl;
@@ -102,9 +102,9 @@ fn capture_handler(error: &(dyn Diagnostic + 'static)) -> Box<dyn ReportHandler>
 }
 
 fn get_default_printer(_err: &(dyn Diagnostic + 'static)) -> Box<dyn ReportHandler + 'static> {
-    #[cfg(feature = "fancy-no-backtrace")]
+    #[cfg(feature = "fancy-no-syscall")]
     return Box::new(MietteHandler::new());
-    #[cfg(not(feature = "fancy-no-backtrace"))]
+    #[cfg(not(feature = "fancy-no-syscall"))]
     return Box::new(DebugReportHandler::new());
 }
 

--- a/src/eyreish/mod.rs
+++ b/src/eyreish/mod.rs
@@ -24,10 +24,10 @@ pub use ReportHandler as EyreContext;
 #[allow(unreachable_pub)]
 pub use WrapErr as Context;
 
-#[cfg(not(feature = "fancy-no-syscall"))]
+#[cfg(not(feature = "fancy-base"))]
 use crate::DebugReportHandler;
 use crate::Diagnostic;
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 use crate::MietteHandler;
 
 use error::ErrorImpl;
@@ -102,9 +102,9 @@ fn capture_handler(error: &(dyn Diagnostic + 'static)) -> Box<dyn ReportHandler>
 }
 
 fn get_default_printer(_err: &(dyn Diagnostic + 'static)) -> Box<dyn ReportHandler + 'static> {
-    #[cfg(feature = "fancy-no-syscall")]
+    #[cfg(feature = "fancy-base")]
     return Box::new(MietteHandler::new());
-    #[cfg(not(feature = "fancy-no-syscall"))]
+    #[cfg(not(feature = "fancy-base"))]
     return Box::new(DebugReportHandler::new());
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -431,7 +431,7 @@ mod syscall {
     #[inline]
     pub(super) fn supports_hyperlinks() -> bool {
         cfg_if! {
-            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+            if #[cfg(feature = "fancy-no-syscall")] {
                 false
             } else {
                 supports_hyperlinks::on(supports_hyperlinks::Stream::Stderr)
@@ -443,7 +443,7 @@ mod syscall {
     #[inline]
     pub(super) fn supports_color() -> bool {
         cfg_if! {
-            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+            if #[cfg(feature = "fancy-no-syscall")] {
                 false
             } else {
                 supports_color::on(supports_color::Stream::Stderr).is_some()
@@ -454,7 +454,7 @@ mod syscall {
     #[inline]
     pub(super) fn supports_color_has_16m() -> Option<bool> {
         cfg_if! {
-            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+            if #[cfg(feature = "fancy-no-syscall")] {
                 None
             } else {
                 supports_color::on(supports_color::Stream::Stderr).map(|color| color.has_16m)
@@ -465,7 +465,7 @@ mod syscall {
     #[inline]
     pub(super) fn supports_unicode() -> bool {
         cfg_if! {
-            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+            if #[cfg(feature = "fancy-no-syscall")] {
                 false
             } else {
                 supports_unicode::on(supports_unicode::Stream::Stderr)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -265,17 +265,15 @@ impl MietteHandlerOpts {
             let characters = match self.unicode {
                 Some(true) => ThemeCharacters::unicode(),
                 Some(false) => ThemeCharacters::ascii(),
-                None if supports_unicode::on(supports_unicode::Stream::Stderr) => {
-                    ThemeCharacters::unicode()
-                }
+                None if syscall::supports_unicode() => ThemeCharacters::unicode(),
                 None => ThemeCharacters::ascii(),
             };
             let styles = if self.color == Some(false) {
                 ThemeStyles::none()
-            } else if let Some(color) = supports_color::on(supports_color::Stream::Stderr) {
+            } else if let Some(color_has_16m) = syscall::supports_color_has_16m() {
                 match self.rgb_colors {
                     RgbColors::Always => ThemeStyles::rgb(),
-                    RgbColors::Preferred if color.has_16m => ThemeStyles::rgb(),
+                    RgbColors::Preferred if color_has_16m => ThemeStyles::rgb(),
                     _ => ThemeStyles::ansi(),
                 }
             } else if self.color == Some(true) {
@@ -291,9 +289,7 @@ impl MietteHandlerOpts {
             #[cfg(feature = "syntect-highlighter")]
             let highlighter = if self.color == Some(false) {
                 MietteHighlighter::nocolor()
-            } else if self.color == Some(true)
-                || supports_color::on(supports_color::Stream::Stderr).is_some()
-            {
+            } else if self.color == Some(true) || syscall::supports_color() {
                 match self.highlighter {
                     Some(highlighter) => highlighter,
                     None => match self.rgb_colors {
@@ -366,26 +362,13 @@ impl MietteHandlerOpts {
         if let Some(linkify) = self.linkify {
             linkify
         } else {
-            supports_hyperlinks::on(supports_hyperlinks::Stream::Stderr)
+            syscall::supports_hyperlinks()
         }
     }
 
-    #[cfg(not(miri))]
     pub(crate) fn get_width(&self) -> usize {
-        self.width.unwrap_or_else(|| {
-            terminal_size::terminal_size()
-                .unwrap_or((terminal_size::Width(80), terminal_size::Height(0)))
-                .0
-                 .0 as usize
-        })
-    }
-
-    #[cfg(miri)]
-    // miri doesn't support a syscall (specifically ioctl)
-    // performed by terminal_size, which causes test execution to fail
-    // so when miri is running we'll just fallback to a constant
-    pub(crate) fn get_width(&self) -> usize {
-        self.width.unwrap_or(80)
+        self.width
+            .unwrap_or_else(|| syscall::terminal_width().unwrap_or(80))
     }
 }
 
@@ -428,5 +411,65 @@ impl ReportHandler for MietteHandler {
         }
 
         self.inner.debug(diagnostic, f)
+    }
+}
+
+mod syscall {
+    use cfg_if::cfg_if;
+
+    #[inline]
+    pub(super) fn terminal_width() -> Option<usize> {
+        cfg_if! {
+            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+                None
+            } else {
+                terminal_size::terminal_size().map(|size| size.0 .0 as usize)
+            }
+        }
+    }
+
+    #[inline]
+    pub(super) fn supports_hyperlinks() -> bool {
+        cfg_if! {
+            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+                false
+            } else {
+                supports_hyperlinks::on(supports_hyperlinks::Stream::Stderr)
+            }
+        }
+    }
+
+    #[cfg(feature = "syntect-highlighter")]
+    #[inline]
+    pub(super) fn supports_color() -> bool {
+        cfg_if! {
+            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+                false
+            } else {
+                supports_color::on(supports_color::Stream::Stderr).is_some()
+            }
+        }
+    }
+
+    #[inline]
+    pub(super) fn supports_color_has_16m() -> Option<bool> {
+        cfg_if! {
+            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+                None
+            } else {
+                supports_color::on(supports_color::Stream::Stderr).map(|color| color.has_16m)
+            }
+        }
+    }
+
+    #[inline]
+    pub(super) fn supports_unicode() -> bool {
+        cfg_if! {
+            if #[cfg(any(feature = "fancy-no-syscall", miri))] {
+                false
+            } else {
+                supports_unicode::on(supports_unicode::Stream::Stderr)
+            }
+        }
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -5,20 +5,20 @@ Reporters included with `miette`.
 #[allow(unreachable_pub)]
 pub use debug::*;
 #[allow(unreachable_pub)]
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 pub use graphical::*;
 #[allow(unreachable_pub)]
 pub use json::*;
 #[allow(unreachable_pub)]
 pub use narratable::*;
 #[allow(unreachable_pub)]
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 pub use theme::*;
 
 mod debug;
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 mod graphical;
 mod json;
 mod narratable;
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 mod theme;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -5,20 +5,20 @@ Reporters included with `miette`.
 #[allow(unreachable_pub)]
 pub use debug::*;
 #[allow(unreachable_pub)]
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 pub use graphical::*;
 #[allow(unreachable_pub)]
 pub use json::*;
 #[allow(unreachable_pub)]
 pub use narratable::*;
 #[allow(unreachable_pub)]
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 pub use theme::*;
 
 mod debug;
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 mod graphical;
 mod json;
 mod narratable;
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 mod theme;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,7 +760,7 @@ pub use miette_derive::*;
 
 pub use error::*;
 pub use eyreish::*;
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 pub use handler::*;
 pub use handlers::*;
 pub use miette_diagnostic::*;
@@ -773,10 +773,10 @@ mod chain;
 mod diagnostic_chain;
 mod error;
 mod eyreish;
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 mod handler;
 mod handlers;
-#[cfg(feature = "fancy-no-syscall")]
+#[cfg(feature = "fancy-base")]
 pub mod highlighters;
 #[doc(hidden)]
 pub mod macro_helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,7 +760,7 @@ pub use miette_derive::*;
 
 pub use error::*;
 pub use eyreish::*;
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 pub use handler::*;
 pub use handlers::*;
 pub use miette_diagnostic::*;
@@ -773,10 +773,10 @@ mod chain;
 mod diagnostic_chain;
 mod error;
 mod eyreish;
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 mod handler;
 mod handlers;
-#[cfg(feature = "fancy-no-backtrace")]
+#[cfg(feature = "fancy-no-syscall")]
 pub mod highlighters;
 #[doc(hidden)]
 pub mod macro_helpers;


### PR DESCRIPTION
* closes https://github.com/zkat/miette/issues/346
* closes https://github.com/zkat/miette/pull/326

I added 

* `fancy-base` feature to enable exports for the `fancy` feature
* `fancy-no-syscall` feature to disable all syscalls
* a `wasm` ci check to ensure future changes.


`target_family = "wasm"` will not work in this case because `terminal_size` will not compile under `wasm32-unknown-unknown`, the dependency has to be excluded.