### PR TITLE
doc: add `severity` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ then you may want to use [`miette!`], [`diagnostic!`] macros or
 
 let source = "2 + 2 * 2 = 8".to_string();
 let report = miette!(
-  labels = vec[
+  labels = vec![
       LabeledSpan::at(12..13, "this should be 6"),
   ],
   help = "'*' has greater precedence than '+'",

--- a/README.md
+++ b/README.md
@@ -34,24 +34,29 @@ libraries and such might not want.
 
 ### Table of Contents <!-- omit in toc -->
 
-- [About](#about)
-- [Features](#features)
-- [Installing](#installing)
-- [Example](#example)
-- [Using](#using)
-  - [... in libraries](#-in-libraries)
-  - [... in application code](#-in-application-code)
-  - [... in `main()`](#-in-main)
-  - [... diagnostic code URLs](#-diagnostic-code-urls)
-  - [... snippets](#-snippets)
-  - [... multiple related errors](#-multiple-related-errors)
-  - [... delayed source code](#-delayed-source-code)
-  - [... handler options](#-handler-options)
-  - [... dynamic diagnostics](#-dynamic-diagnostics)
-  - [... syntax highlighting](#-syntax-highlighting)
-  - [... collection of labels](#-collection-of-labels)
-- [Acknowledgements](#acknowledgements)
-- [License](#license)
+- [`miette`](#miette)
+    - [About](#about)
+    - [Features](#features)
+    - [Installing](#installing)
+    - [Example](#example)
+    - [Using](#using)
+      - [... in libraries](#-in-libraries)
+      - [... in application code](#-in-application-code)
+      - [... in `main()`](#-in-main)
+      - [... diagnostic code URLs](#-diagnostic-code-urls)
+      - [... snippets](#-snippets)
+      - [... help text](#-help-text)
+      - [... severity level](#-severity-level)
+      - [... multiple related errors](#-multiple-related-errors)
+      - [... delayed source code](#-delayed-source-code)
+      - [... Diagnostic-based error sources.](#-diagnostic-based-error-sources)
+      - [... handler options](#-handler-options)
+      - [... dynamic diagnostics](#-dynamic-diagnostics)
+      - [... syntax highlighting](#-syntax-highlighting)
+      - [... collection of labels](#-collection-of-labels)
+    - [MSRV](#msrv)
+    - [Acknowledgements](#acknowledgements)
+    - [License](#license)
 
 ### Features
 
@@ -425,7 +430,7 @@ pub struct MyErrorType {
 }
 ```
 
-##### ... help text
+#### ... help text
 `miette` provides two facilities for supplying help text for your errors:
 
 The first is the `#[help()]` format attribute that applies to structs or
@@ -459,6 +464,19 @@ struct Foo {
 let err = Foo {
     advice: Some("try doing this instead".to_string()),
 };
+```
+
+#### ... severity level
+`miette` provides a way to set the severity level of a diagnostic.
+
+```rust
+use miette::Diagnostic;
+use thiserror::Error;
+
+#[derive(Debug, Diagnostic, Error)]
+#[error("welp")]
+#[diagnostic(severity("warning"))]
+struct Foo;
 ```
 
 #### ... multiple related errors

--- a/README.md
+++ b/README.md
@@ -34,29 +34,24 @@ libraries and such might not want.
 
 ### Table of Contents <!-- omit in toc -->
 
-- [`miette`](#miette)
-    - [About](#about)
-    - [Features](#features)
-    - [Installing](#installing)
-    - [Example](#example)
-    - [Using](#using)
-      - [... in libraries](#-in-libraries)
-      - [... in application code](#-in-application-code)
-      - [... in `main()`](#-in-main)
-      - [... diagnostic code URLs](#-diagnostic-code-urls)
-      - [... snippets](#-snippets)
-      - [... help text](#-help-text)
-      - [... severity level](#-severity-level)
-      - [... multiple related errors](#-multiple-related-errors)
-      - [... delayed source code](#-delayed-source-code)
-      - [... Diagnostic-based error sources.](#-diagnostic-based-error-sources)
-      - [... handler options](#-handler-options)
-      - [... dynamic diagnostics](#-dynamic-diagnostics)
-      - [... syntax highlighting](#-syntax-highlighting)
-      - [... collection of labels](#-collection-of-labels)
-    - [MSRV](#msrv)
-    - [Acknowledgements](#acknowledgements)
-    - [License](#license)
+- [About](#about)
+- [Features](#features)
+- [Installing](#installing)
+- [Example](#example)
+- [Using](#using)
+  - [... in libraries](#-in-libraries)
+  - [... in application code](#-in-application-code)
+  - [... in `main()`](#-in-main)
+  - [... diagnostic code URLs](#-diagnostic-code-urls)
+  - [... snippets](#-snippets)
+  - [... multiple related errors](#-multiple-related-errors)
+  - [... delayed source code](#-delayed-source-code)
+  - [... handler options](#-handler-options)
+  - [... dynamic diagnostics](#-dynamic-diagnostics)
+  - [... syntax highlighting](#-syntax-highlighting)
+  - [... collection of labels](#-collection-of-labels)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 ### Features
 
@@ -475,7 +470,7 @@ use thiserror::Error;
 
 #[derive(Debug, Diagnostic, Error)]
 #[error("welp")]
-#[diagnostic(severity("warning"))]
+#[diagnostic(severity(Warning))]
 struct Foo;
 ```
 


### PR DESCRIPTION
I only found out how to use this after reading all the test cases.

I think it's better to appear in the readme. hah~