### PR TITLE
Fix clippy lints in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ fn this_fails() -> Result<()> {
     // You can use plain strings as a `Source`, or anything that implements
     // the one-method `Source` trait.
     let src = "source\n  text\n    here".to_string();
-    let len = src.len();
 
     Err(MyBad {
         src: NamedSource::new("bad_file.rs", src),
@@ -247,7 +246,7 @@ use miette::{IntoDiagnostic, Result};
 use semver::Version;
 
 pub fn some_tool() -> Result<Version> {
-    Ok("1.2.x".parse().into_diagnostic()?)
+    "1.2.x".parse().into_diagnostic()
 }
 ```
 
@@ -262,24 +261,24 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use semver::Version;
 
 pub fn some_tool() -> Result<Version> {
-    Ok("1.2.x"
+    "1.2.x"
         .parse()
         .into_diagnostic()
-        .wrap_err("Parsing this tool's semver version failed.")?)
+        .wrap_err("Parsing this tool's semver version failed.")
 }
 ```
 
 To construct your own simple adhoc error use the [miette!] macro:
 ```rust
 // my_app/lib/my_internal_file.rs
-use miette::{miette, IntoDiagnostic, Result, WrapErr};
+use miette::{miette, Result};
 use semver::Version;
 
 pub fn some_tool() -> Result<Version> {
     let version = "1.2.x";
-    Ok(version
+    version
         .parse()
-        .map_err(|_| miette!("Invalid version {}", version))?)
+        .map_err(|_| miette!("Invalid version {}", version))
 }
 ```
 There are also similar [bail!] and [ensure!] macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@
 //!     // You can use plain strings as a `Source`, or anything that implements
 //!     // the one-method `Source` trait.
 //!     let src = "source\n  text\n    here".to_string();
-//!     let len = src.len();
 //!
 //!     Err(MyBad {
 //!         src: NamedSource::new("bad_file.rs", src),
@@ -246,7 +245,7 @@
 //! use semver::Version;
 //!
 //! pub fn some_tool() -> Result<Version> {
-//!     Ok("1.2.x".parse().into_diagnostic()?)
+//!     "1.2.x".parse().into_diagnostic()
 //! }
 //! ```
 //!
@@ -261,24 +260,24 @@
 //! use semver::Version;
 //!
 //! pub fn some_tool() -> Result<Version> {
-//!     Ok("1.2.x"
+//!     "1.2.x"
 //!         .parse()
 //!         .into_diagnostic()
-//!         .wrap_err("Parsing this tool's semver version failed.")?)
+//!         .wrap_err("Parsing this tool's semver version failed.")
 //! }
 //! ```
 //!
 //! To construct your own simple adhoc error use the [miette!] macro:
 //! ```rust
 //! // my_app/lib/my_internal_file.rs
-//! use miette::{miette, IntoDiagnostic, Result, WrapErr};
+//! use miette::{miette, Result};
 //! use semver::Version;
 //!
 //! pub fn some_tool() -> Result<Version> {
 //!     let version = "1.2.x";
-//!     Ok(version
+//!     version
 //!         .parse()
-//!         .map_err(|_| miette!("Invalid version {}", version))?)
+//!         .map_err(|_| miette!("Invalid version {}", version))
 //! }
 //! ```
 //! There are also similar [bail!] and [ensure!] macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,7 +637,6 @@
 //!     )
 //! }))
 //!
-//! # .unwrap()
 //! ```
 //!
 //! See the docs for [`MietteHandlerOpts`] for more details on what you can


### PR DESCRIPTION
One example:

```sh
dape-tester on  main [!+?] is 📦 v0.1.0 via 🦀 v1.79.0-nightly via ❄️  impure (nix-shell-env)
❯ cargo clippy --all-targets
warning: unused imports: `IntoDiagnostic`, `WrapErr`
 --> src/my_internal_file3.rs:1:22
  |
1 | use miette::{miette, IntoDiagnostic, Result, WrapErr};
  |                      ^^^^^^^^^^^^^^          ^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: question mark operator is useless here
 --> src/my_internal_file3.rs:6:5
  |
6 | /     Ok(version
7 | |         .parse()
8 | |         .map_err(|_| miette!("Invalid version {}", version))?)
  | |______________________________________________________________^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark
  = note: `#[warn(clippy::needless_question_mark)]` on by default
help: try removing question mark and `Ok()`
  |
6 ~     version
7 +         .parse()
8 +         .map_err(|_| miette!("Invalid version {}", version))
  |

warning: `dape-tester` (bin "dape-tester") generated 2 warnings (run `cargo clippy --fix --bin "dape-tester"` to apply 2 suggestions)
warning: `dape-tester` (bin "dape-tester" test) generated 2 warnings (2 duplicates)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s

dape-tester on  main [!+?] is 📦 v0.1.0 via 🦀 v1.79.0-nightly via ❄️  impure (nix-shell-env
```
Image of above text:

![20240412_22h39m37s_grim](https://github.com/zkat/miette/assets/2023546/d4e7b277-098e-474a-b803-f34da0cb577b)

Also deleted a commented out `unwrap` found in lib.rs that's not found in the readme.