### PR TITLE
Turns out, `Report` *really* doesn't want to be an `Error` or `Diagnostic`...

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,2 @@
+[language-server.rust-analyzer]
+config = { cargo = { features = "all" } }

--- a/src/eyreish/context.rs
+++ b/src/eyreish/context.rs
@@ -1,4 +1,4 @@
-use super::error::{ContextError, ErrorImpl};
+use super::error::ContextError;
 use super::{Report, WrapErr};
 use core::fmt::{self, Debug, Display, Write};
 
@@ -25,15 +25,6 @@ mod ext {
             D: Display + Send + Sync + 'static,
         {
             Report::from_msg(msg, self)
-        }
-    }
-
-    impl Diag for Report {
-        fn ext_report<D>(self, msg: D) -> Report
-        where
-            D: Display + Send + Sync + 'static,
-        {
-            self.wrap_err(msg)
         }
     }
 }
@@ -111,15 +102,6 @@ where
     }
 }
 
-impl<D> StdError for ContextError<D, Report>
-where
-    D: Display,
-{
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        unsafe { Some(ErrorImpl::error(self.error.inner.by_ref())) }
-    }
-}
-
 impl<D, E> Diagnostic for ContextError<D, E>
 where
     D: Display,
@@ -143,39 +125,6 @@ where
 
     fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
         self.error.labels()
-    }
-
-    fn source_code(&self) -> Option<&dyn crate::SourceCode> {
-        self.error.source_code()
-    }
-
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
-        self.error.related()
-    }
-}
-
-impl<D> Diagnostic for ContextError<D, Report>
-where
-    D: Display,
-{
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).code() }
-    }
-
-    fn severity(&self) -> Option<crate::Severity> {
-        unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).severity() }
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).help() }
-    }
-
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).url() }
-    }
-
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
-        unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).labels() }
     }
 
     fn source_code(&self) -> Option<&dyn crate::SourceCode> {

--- a/src/eyreish/into_diagnostic.rs
+++ b/src/eyreish/into_diagnostic.rs
@@ -28,6 +28,6 @@ pub trait IntoDiagnostic<T, E> {
 
 impl<T, E: std::error::Error + Send + Sync + 'static> IntoDiagnostic<T, E> for Result<T, E> {
     fn into_diagnostic(self) -> Result<T, Report> {
-        self.map_err(|e| DiagnosticError(Box::new(e)).into())
+        self.map_err(|e| Report::new(DiagnosticError(Box::new(e))))
     }
 }

--- a/src/eyreish/kind.rs
+++ b/src/eyreish/kind.rs
@@ -80,15 +80,15 @@ pub trait TraitKind: Sized {
     }
 }
 
-impl<E> TraitKind for E where E: Into<Report> {}
+impl<E> TraitKind for E where E: Diagnostic + Send + Sync + 'static {}
 
 impl Trait {
     #[cfg_attr(track_caller, track_caller)]
     pub fn new<E>(self, error: E) -> Report
     where
-        E: Into<Report>,
+        E: Diagnostic + Send + Sync + 'static,
     {
-        error.into()
+        Report::new(error)
     }
 }
 

--- a/src/eyreish/macros.rs
+++ b/src/eyreish/macros.rs
@@ -228,7 +228,7 @@ macro_rules! ensure {
 #[macro_export]
 macro_rules! miette {
     ($($key:ident = $value:expr,)* $fmt:literal $($arg:tt)*) => {
-        $crate::Report::from(
+        $crate::Report::new(
             $crate::diagnostic!($($key = $value,)* $fmt $($arg)*)
         )
     };

--- a/src/eyreish/ptr.rs
+++ b/src/eyreish/ptr.rs
@@ -58,6 +58,8 @@ where
     }
 }
 
+// FIXME: Delete this derive!
+#[derive(Debug)]
 #[allow(explicit_outlives_requirements)]
 #[repr(transparent)]
 /// A raw pointer that represents a shared borrow of its pointee

--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Debug, Display};
 
 use std::error::Error as StdError;
 
-use crate::{Diagnostic, LabeledSpan, Report, SourceCode};
+use crate::{Diagnostic, LabeledSpan, SourceCode};
 
 use crate as miette;
 
@@ -134,40 +134,6 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
     }
 }
 
-impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.error.code()
-    }
-
-    fn severity(&self) -> Option<miette::Severity> {
-        self.error.severity()
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.error.help()
-    }
-
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.error.url()
-    }
-
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
-        self.error.labels()
-    }
-
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        self.error.source_code().or(Some(&self.source_code))
-    }
-
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
-        self.error.related()
-    }
-
-    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
-        self.error.diagnostic_source()
-    }
-}
-
 impl<E: Debug, C> Debug for WithSourceCode<E, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&self.error, f)
@@ -181,12 +147,6 @@ impl<E: Display, C> Display for WithSourceCode<E, C> {
 }
 
 impl<E: StdError, C> StdError for WithSourceCode<E, C> {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.error.source()
-    }
-}
-
-impl<C> StdError for WithSourceCode<Report, C> {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         self.error.source()
     }
@@ -232,7 +192,7 @@ mod tests {
         let inner_source = "hello world";
         let outer_source = "abc";
 
-        let report = Report::from(Inner {
+        let report = Report::new(Inner {
             at: (0..5).into(),
             source_code: Some(inner_source.to_string()),
         })
@@ -257,7 +217,7 @@ mod tests {
         let inner_source = "hello world";
         let outer_source = "abc";
 
-        let report = Report::from(Outer {
+        let report = Report::new(Outer {
             errors: vec![
                 Inner {
                     at: (0..5).into(),

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,7 +1,7 @@
 use backtrace::Backtrace;
 use thiserror::Error;
 
-use crate::{self as miette, Context, Diagnostic, Result};
+use crate::{self as miette, Context, Diagnostic, Report, Result};
 
 /// Tells miette to render panics using its rendering engine.
 pub fn set_panic_hook() {
@@ -14,7 +14,7 @@ pub fn set_panic_hook() {
         if let Some(msg) = payload.downcast_ref::<String>() {
             message = msg.clone();
         }
-        let mut report: Result<()> = Err(Panic(message).into());
+        let mut report: Result<()> = Err(Report::new(Panic(message)));
         if let Some(loc) = info.location() {
             report = report
                 .with_context(|| format!("at {}:{}:{}", loc.file(), loc.line(), loc.column()));

--- a/tests/narrated.rs
+++ b/tests/narrated.rs
@@ -1,22 +1,22 @@
 #![cfg(feature = "fancy-no-backtrace")]
 
-use miette::{Diagnostic, MietteError, NamedSource, NarratableReportHandler, Report, SourceSpan};
+use miette::{Diagnostic, MietteError, NamedSource, NarratableReportHandler, SourceSpan};
 
 use miette::{GraphicalReportHandler, GraphicalTheme};
 
 use thiserror::Error;
 
-fn fmt_report(diag: Report) -> String {
+fn fmt_report(diag: impl Diagnostic) -> String {
     let mut out = String::new();
     // Mostly for dev purposes.
     if cfg!(feature = "fancy-no-backtrace") && std::env::var("STYLE").is_ok() {
         #[cfg(feature = "fancy-no-backtrace")]
         GraphicalReportHandler::new_themed(GraphicalTheme::unicode())
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, &diag)
             .unwrap();
     } else {
         NarratableReportHandler::new()
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, &diag)
             .unwrap();
     };
     out
@@ -39,7 +39,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (9, 6).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -75,7 +75,7 @@ fn single_line_highlight() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (9, 4).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -111,7 +111,7 @@ fn single_line_highlight_offset_zero() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (0, 0).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -146,7 +146,7 @@ fn single_line_highlight_with_empty_span() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (9, 0).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -182,7 +182,7 @@ fn single_line_highlight_no_label() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (9, 4).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -218,7 +218,7 @@ fn single_line_highlight_at_line_start() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (7, 4).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -260,7 +260,7 @@ fn multiple_same_line_highlights() -> Result<(), MietteError> {
         highlight2: (14, 4).into(),
         highlight3: (24, 4).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -298,7 +298,7 @@ fn multiline_highlight_adjacent() -> Result<(), MietteError> {
         src: NamedSource::new("bad_file.rs", src),
         highlight: (9, 11).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -345,7 +345,7 @@ line5
         highlight1: (0, len).into(),
         highlight2: (10, 9).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -407,7 +407,7 @@ line5
         highlight1: (0, len).into(),
         highlight2: (10, 9).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = "wtf?!
 it broke :(
@@ -457,7 +457,7 @@ fn multiple_multiline_highlights_adjacent() -> Result<(), MietteError> {
         highlight1: (0, 10).into(),
         highlight2: (20, 6).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = "oops!
     Diagnostic severity: error
@@ -505,7 +505,7 @@ fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> 
         highlight1: (0, 8).into(),
         highlight2: (9, 10).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     assert_eq!("Error [oops::my::bad]: oops!\n\n[bad_file.rs] This is the part that broke:\n\n 1 │ source\n 2 │   text\n   ·   ──┬─\n   ·     ╰── this bit here\n 3 │     here\n\n﹦ try doing it better next time?\n".to_string(), out);
     Ok(())
@@ -533,7 +533,7 @@ fn multiple_multiline_highlights_overlapping_offsets() -> Result<(), MietteError
         highlight1: (0, 8).into(),
         highlight2: (10, 10).into(),
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     assert_eq!("Error [oops::my::bad]: oops!\n\n[bad_file.rs] This is the part that broke:\n\n 1 │ source\n 2 │   text\n   ·   ──┬─\n   ·     ╰── this bit here\n 3 │     here\n\n﹦ try doing it better next time?\n".to_string(), out);
     Ok(())
@@ -546,7 +546,7 @@ fn url() -> Result<(), MietteError> {
     #[diagnostic(help("try doing it better next time?"), url("https://example.com"))]
     struct MyBad;
     let err = MyBad;
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     assert!(out.contains("https://example.com"));
     Ok(())
@@ -576,7 +576,7 @@ fn related() -> Result<(), MietteError> {
             related: vec![],
         }],
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error
@@ -637,7 +637,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
             highlight: (0, 6).into(),
         }],
     };
-    let out = fmt_report(err.into());
+    let out = fmt_report(err);
     println!("Error: {}", out);
     let expected = r#"oops!
     Diagnostic severity: error

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -43,7 +43,9 @@ fn test_boxed_thiserror() {
     let error = MyError {
         source: io::Error::new(io::ErrorKind::Other, "oh no!"),
     };
+    dbg!(&error, error.source());
     let report: Report = miette!(error);
+    dbg!(&report, report.source());
     assert_eq!("oh no!", report.source().unwrap().to_string());
 
     let error = MyError {
@@ -218,7 +220,6 @@ fn test_boxed_custom_diagnostic() {
 }
 
 #[test]
-#[ignore = "I don't know why this isn't working but it needs fixing."]
 fn test_boxed_sources() {
     let error = MyError {
         source: io::Error::new(io::ErrorKind::Other, "oh no!"),

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,14 +1,14 @@
 mod json_report_handler {
-    use miette::{Diagnostic, MietteError, NamedSource, Report, SourceSpan};
+    use miette::{Diagnostic, MietteError, NamedSource, SourceSpan};
 
     use miette::JSONReportHandler;
 
     use thiserror::Error;
 
-    fn fmt_report(diag: Report) -> String {
+    fn fmt_report(diag: impl Diagnostic) -> String {
         let mut out = String::new();
         JSONReportHandler::new()
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, &diag)
             .unwrap();
         out
     }
@@ -30,7 +30,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (9, 6).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -75,7 +75,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (9, 4).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -120,7 +120,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (0, 0).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -165,7 +165,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (9, 0).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -210,7 +210,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (9, 4).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -254,7 +254,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (7, 4).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -305,7 +305,7 @@ mod json_report_handler {
             highlight2: (14, 4).into(),
             highlight3: (24, 4).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -364,7 +364,7 @@ mod json_report_handler {
             src: NamedSource::new("bad_file.rs", src),
             highlight: (9, 11).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -419,7 +419,7 @@ mod json_report_handler {
             highlight1: (0, len).into(),
             highlight2: (10, 9).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -492,7 +492,7 @@ mod json_report_handler {
             highlight1: (0, len).into(),
             highlight2: (10, 9).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -549,7 +549,7 @@ mod json_report_handler {
             highlight1: (0, 10).into(),
             highlight2: (20, 6).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -604,7 +604,7 @@ mod json_report_handler {
             highlight1: (0, 8).into(),
             highlight2: (9, 10).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -659,7 +659,7 @@ mod json_report_handler {
             highlight1: (0, 8).into(),
             highlight2: (10, 10).into(),
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -702,7 +702,7 @@ mod json_report_handler {
         struct MyBad;
 
         let err = MyBad;
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -752,7 +752,7 @@ mod json_report_handler {
                 },
             ],
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {
@@ -849,7 +849,7 @@ mod json_report_handler {
                 },
             ],
         };
-        let out = fmt_report(err.into());
+        let out = fmt_report(err);
         println!("Error: {}", out);
         let expected: String = r#"
         {


### PR DESCRIPTION
Failing some context tests, I'm pretty sure because `self.wrap_err(msg)` creates a `context_chain_downcast` table, whilst the `Report::from_msg(msg, self)` that it's impl clashed with only creates at `context_downcast`.

I messed around and got Rust to segfault, and discovered I was very much in over my head...

I do think it's possible to `impl Diagnostic for Report`, but there's a lot of internal restructuring that would need to happen, and *in the best case*, we lose the `Into<Report>` impl.

As with 90%+ of my issues with Rust nowadays, the stabilization of specialization would solve this (I believe), but that could be ages and ages away still...

Ultimately, this is here if anyone is feeling clever / brave, and it's work thinking about if we're okay losing those `From` and `Into` impls for `Report`, because I don't think there is a clever way around that...