### PR TITLE
Fix #369 (Loss of `Diagnostic` information when `Report` is converted to `Box<dyn Diagnostic>`)

### DIFF
--- a/src/eyreish/error.rs
+++ b/src/eyreish/error.rs
@@ -533,7 +533,8 @@ where
     E: Diagnostic + Send + Sync + 'static,
 {
     // Attach ErrorImpl<E>'s native StdError vtable. The StdError impl is below.
-    e.cast::<ErrorImpl<E>>().boxed()
+    let unerased = e.cast::<ErrorImpl<E>>().boxed();
+    Box::new(unerased._object)
 }
 
 // Safety: requires layout of *e to match ErrorImpl<E>.
@@ -544,7 +545,8 @@ where
     E: StdError + Send + Sync + 'static,
 {
     // Attach ErrorImpl<E>'s native StdError vtable. The StdError impl is below.
-    e.cast::<ErrorImpl<E>>().boxed()
+    let unerased = e.cast::<ErrorImpl<E>>().boxed();
+    Box::new(unerased._object)
 }
 
 // Safety: requires layout of *e to match ErrorImpl<E>.
@@ -715,17 +717,6 @@ impl ErasedErrorImpl {
         Chain::new(Self::error(this))
     }
 }
-
-impl<E> StdError for ErrorImpl<E>
-where
-    E: StdError,
-{
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        unsafe { ErrorImpl::diagnostic(self.erase()).source() }
-    }
-}
-
-impl<E> Diagnostic for ErrorImpl<E> where E: Diagnostic {}
 
 impl<E> Debug for ErrorImpl<E>
 where

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -218,7 +218,6 @@ fn test_boxed_custom_diagnostic() {
 }
 
 #[test]
-#[ignore = "I don't know why this isn't working but it needs fixing."]
 fn test_boxed_sources() {
     let error = MyError {
         source: io::Error::new(io::ErrorKind::Other, "oh no!"),


### PR DESCRIPTION
Fixes #369

The culprit was:

https://github.com/zkat/miette/blob/ea4296dacec3b0e4762281d9d115c1bd69ecfac3/src/eyreish/error.rs#L728

In conjunction with:

https://github.com/zkat/miette/blob/ea4296dacec3b0e4762281d9d115c1bd69ecfac3/src/eyreish/error.rs#L531-L537

Which converts a `Box<ErrorImpl<E>>` into the `Box<dyn Diagnostic>`, hence the resultant object ends up with the empty `Diagnostic` impl defined above!

This fix moves the `_object` out of the `Box<ErrorImpl<E>>` to create a `Box<E>` before conversion to `Box<dyn Diagnostic>`, attaching the correct `Diagnostic` impl for the *original* error `E`.

Miri seems happy, and I've actually only added safe code, even though it's in an `unsafe` function because of `.boxed()` which I left untouched.

---

As a side note, the only reason converting to `Box<dyn Error>` worked is because of this manual pass-through done here:
https://github.com/zkat/miette/blob/ea4296dacec3b0e4762281d9d115c1bd69ecfac3/src/eyreish/error.rs#L719-L726

But now that we aren't ever trying to convert `ErrorImpl<E>`s into trait objects anymore — directly converting `E`s instead — I've deleted that unused code.