### PR TITLE
 feat!(render): render_report can accept more types

### DIFF
--- a/src/handlers/debug.rs
+++ b/src/handlers/debug.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{protocol::Diagnostic, ReportHandler};
+use crate::{protocol::Diagnostic, AsDiagnostic, ReportHandler};
 
 /**
 [`ReportHandler`] that renders plain text and avoids extraneous graphics.
@@ -31,8 +31,9 @@ impl DebugReportHandler {
     pub fn render_report(
         &self,
         f: &mut fmt::Formatter<'_>,
-        diagnostic: &(dyn Diagnostic),
+        diagnostic: impl AsDiagnostic,
     ) -> fmt::Result {
+        let diagnostic = diagnostic.as_dyn();
         let mut diag = f.debug_struct("Diagnostic");
         diag.field("message", &format!("{}", diagnostic));
         if let Some(code) = diagnostic.code() {

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -7,7 +7,7 @@ use crate::diagnostic_chain::{DiagnosticChain, ErrorKind};
 use crate::handlers::theme::*;
 use crate::highlighters::{Highlighter, MietteHighlighter};
 use crate::protocol::{Diagnostic, Severity};
-use crate::{LabeledSpan, ReportHandler, SourceCode, SourceSpan, SpanContents};
+use crate::{AsDiagnostic, LabeledSpan, ReportHandler, SourceCode, SourceSpan, SpanContents};
 
 /**
 A [`ReportHandler`] that displays a given [`Report`](crate::Report) in a
@@ -215,8 +215,9 @@ impl GraphicalReportHandler {
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
-        diagnostic: &(dyn Diagnostic),
+        diagnostic: impl AsDiagnostic,
     ) -> fmt::Result {
+        let diagnostic = diagnostic.as_dyn();
         self.render_header(f, diagnostic)?;
         self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    diagnostic_chain::DiagnosticChain, protocol::Diagnostic, ReportHandler, Severity, SourceCode,
+    diagnostic_chain::DiagnosticChain, protocol::Diagnostic, AsDiagnostic, ReportHandler, Severity,
+    SourceCode,
 };
 
 /**
@@ -60,8 +61,9 @@ impl JSONReportHandler {
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
-        diagnostic: &(dyn Diagnostic),
+        diagnostic: impl AsDiagnostic,
     ) -> fmt::Result {
+        let diagnostic = diagnostic.as_dyn();
         self._render_report(f, diagnostic, None)
     }
 

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -4,7 +4,9 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::diagnostic_chain::DiagnosticChain;
 use crate::protocol::{Diagnostic, Severity};
-use crate::{LabeledSpan, MietteError, ReportHandler, SourceCode, SourceSpan, SpanContents};
+use crate::{
+    AsDiagnostic, LabeledSpan, MietteError, ReportHandler, SourceCode, SourceSpan, SpanContents,
+};
 
 /**
 [`ReportHandler`] that renders plain text and avoids extraneous graphics.
@@ -69,8 +71,9 @@ impl NarratableReportHandler {
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
-        diagnostic: &(dyn Diagnostic),
+        diagnostic: impl AsDiagnostic,
     ) -> fmt::Result {
+        let diagnostic = diagnostic.as_dyn();
         self.render_header(f, diagnostic)?;
         if self.with_cause_chain {
             self.render_causes(f, diagnostic)?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -69,6 +69,48 @@ pub trait Diagnostic: std::error::Error {
     }
 }
 
+macro_rules! blanket_ref_impls {
+    ($($ref_type:ty),+ $(,)?) => {
+        $(
+            impl<T: Diagnostic> Diagnostic for $ref_type {
+                fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+                    (**self).code()
+                }
+
+                fn severity(&self) -> Option<Severity> {
+                    (**self).severity()
+                }
+
+                fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+                    (**self).help()
+                }
+
+                fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+                    (**self).url()
+                }
+
+                fn source_code(&self) -> Option<&dyn SourceCode> {
+                    (**self).source_code()
+                }
+
+                fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+                    (**self).labels()
+                }
+
+                fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+                    (**self).related()
+                }
+
+                fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+                    (**self).diagnostic_source()
+                }
+            }
+        )+
+    };
+}
+
+blanket_ref_impls!(&T, Box<T>);
+
 macro_rules! box_error_impls {
     ($($box_type:ty),*) => {
         $(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -12,7 +12,7 @@ use std::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::MietteError;
+use crate::{MietteError, Report};
 
 /// Adds rich metadata to your Error that can be used by
 /// [`Report`](crate::Report) to print really nice and human-friendly error
@@ -228,6 +228,44 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for Box<dyn Diagnostic + Sen
         impl Diagnostic for BoxedDiagnostic {}
 
         Box::new(BoxedDiagnostic(s))
+    }
+}
+
+/// WOOF
+pub trait AsDiagnostic {
+    /// BARK
+    fn as_dyn(&self) -> &dyn Diagnostic;
+}
+
+impl AsDiagnostic for &dyn Diagnostic {
+    fn as_dyn(&self) -> &dyn Diagnostic {
+        *self
+    }
+}
+
+impl AsDiagnostic for Report {
+    fn as_dyn(&self) -> &dyn Diagnostic {
+        self.as_ref()
+    }
+}
+
+macro_rules! blanket_ref_impls {
+    ($($ref_type:ty),+ $(,)?) => {
+        $(
+            impl AsDiagnostic for $ref_type {
+                fn as_dyn(&self) -> &dyn Diagnostic {
+                    (**self).as_dyn()
+                }
+            }
+        )+
+    };
+}
+
+blanket_ref_impls!(&Report, &mut Report, Box<Report>);
+
+impl<T: Diagnostic> AsDiagnostic for T {
+    fn as_dyn(&self) -> &dyn Diagnostic {
+        self
     }
 }
 

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -13,24 +13,24 @@ fn fmt_report(diag: Report) -> String {
         GraphicalReportHandler::new_themed(GraphicalTheme::unicode())
             .with_width(80)
             .with_footer("this is a footer".into())
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, &diag)
             .unwrap();
     } else if std::env::var("NARRATED").is_ok() {
         NarratableReportHandler::new()
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, diag)
             .unwrap();
     } else if let Ok(w) = std::env::var("REPLACE_TABS") {
         GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor())
             .without_syntax_highlighting()
             .with_width(80)
             .tab_width(w.parse().expect("Invalid tab width."))
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, &diag)
             .unwrap();
     } else {
         GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor())
             .without_syntax_highlighting()
             .with_width(80)
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, &diag)
             .unwrap();
     };
     out
@@ -46,7 +46,7 @@ fn fmt_report_with_settings(
         GraphicalTheme::unicode_nocolor(),
     ));
 
-    handler.render_report(&mut out, diag.as_ref()).unwrap();
+    handler.render_report(&mut out, diag).unwrap();
 
     println!("Error:\n```\n{}\n```", out);
 

--- a/tests/narrated.rs
+++ b/tests/narrated.rs
@@ -12,11 +12,11 @@ fn fmt_report(diag: Report) -> String {
     if cfg!(feature = "fancy-no-backtrace") && std::env::var("STYLE").is_ok() {
         #[cfg(feature = "fancy-no-backtrace")]
         GraphicalReportHandler::new_themed(GraphicalTheme::unicode())
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, diag)
             .unwrap();
     } else {
         NarratableReportHandler::new()
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, diag)
             .unwrap();
     };
     out

--- a/tests/test_blanket.rs
+++ b/tests/test_blanket.rs
@@ -1,0 +1,13 @@
+use miette::{Diagnostic, MietteDiagnostic};
+
+fn assert_diagnostic<T: Diagnostic>() {}
+
+#[test]
+fn test_ref() {
+    assert_diagnostic::<&MietteDiagnostic>()
+}
+
+#[test]
+fn test_box() {
+    assert_diagnostic::<Box<MietteDiagnostic>>()
+}

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -8,7 +8,7 @@ mod json_report_handler {
     fn fmt_report(diag: Report) -> String {
         let mut out = String::new();
         JSONReportHandler::new()
-            .render_report(&mut out, diag.as_ref())
+            .render_report(&mut out, diag)
             .unwrap();
         out
     }


### PR DESCRIPTION
This PR builds on PR #367! Merging this should be equivalent to merging both!

You can now pass a `&dyn Diagnostic` (as before), or a `Report` (or `&Report`, `&mut Report`, or `Box<Report>`), or anything else that implements `Diagnostic` to `render_report`.

More generally, users can use the `AsDiagnostic` trait wherever they want to write functions that accept either a `Report` or `Diagnostic` — this improves ergonomics in a world where `impl Diagnostic for Report` is impossible.

BREAKING CHANGE: Because more types can now be passed to `render_report`, `Report::as_ref()` can get confused about types, and inference fails. The solution is removing the `.as_ref()` altogether since `Report` is now a directly accepted type.

This would also effectively close #366 (for my purposes, at least), since anything accepting `AsDiagnostic` will work for `Report` and anything that implements `Diagnostic`!

BEFORE MERGING: After getting the green light from you, but before merging this, I'll have to properly fill in the documentation for `AsDiagnostic`! I don't think `WOOF` and `BARK` is particularly helpful, but I didn't want to write docs before knowing if you'd be interested in accepting this PR!