### PR TITLE
fix(docs): `alt` attribut for `single-line-example.png`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,13 @@ Narratable printout:
 \
 diagnostic error code: oops::my::bad (link)
 Error: oops!
+
 \
 Begin snippet for bad_file.rs starting
 at line 2, column 3
 \
 snippet line 1: source
+
 \
 snippet line 2:  text
     highlight starting at line 1, column 3: This bit here

--- a/README.md
+++ b/README.md
@@ -163,13 +163,11 @@ Narratable printout:
 \
 diagnostic error code: oops::my::bad (link)
 Error: oops!
-
 \
 Begin snippet for bad_file.rs starting
 at line 2, column 3
 \
 snippet line 1: source
-
 \
 snippet line 2:  text
     highlight starting at line 1, column 3: This bit here

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,13 +162,11 @@
 //! \
 //! diagnostic error code: oops::my::bad (link)
 //! Error: oops!
-//!
 //! \
 //! Begin snippet for bad_file.rs starting
 //! at line 2, column 3
 //! \
 //! snippet line 1: source
-//!
 //! \
 //! snippet line 2:  text
 //!     highlight starting at line 1, column 3: This bit here


### PR DESCRIPTION
The white line breaks in the `alt` attribute prevented the `single-line-example.png` image from being displayed.