### PR TITLE
Disable textwrap::smawk feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ unicode-width = "0.1.11"
 cfg-if = "1.0.0"
 
 owo-colors = { version = "4.0.0", optional = true }
-textwrap = { version = "0.16.0", optional = true }
+textwrap = { version = "0.16.0", default-features = false, features = ["unicode-linebreak", "unicode-width"], optional = true }
 supports-hyperlinks = { version = "3.0.0", optional = true }
 supports-color = { version = "3.0.0", optional = true }
 supports-unicode = { version = "3.0.0", optional = true }

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -159,7 +159,7 @@ impl GraphicalReportHandler {
         self
     }
 
-    /// Sets the word splitter to usewhen wrapping.
+    /// Sets the word splitter to use when wrapping.
     pub fn with_word_splitter(mut self, word_splitter: textwrap::WordSplitter) -> Self {
         self.word_splitter = Some(word_splitter);
         self


### PR DESCRIPTION
The goal of this PR is a tiny bit of dependency pruning by not enabling the default "smawk" feature.

While this changes the default line wrapping behaviour slightly, I hope that is okay, but users can also re-enable optimal fit by adding textwrap to their Cargo.toml