### PR TITLE
fix: setting NO_COLOR should not print ansi codes for non-terminals

### DIFF
--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -71,7 +71,7 @@ impl Default for GraphicalTheme {
     fn default() -> Self {
         match std::env::var("NO_COLOR") {
             _ if !std::io::stdout().is_terminal() || !std::io::stderr().is_terminal() => {
-                Self::ascii()
+                Self::none()
             }
             Ok(string) if string != "0" => Self::unicode_nocolor(),
             _ => Self::unicode(),


### PR DESCRIPTION
closes #380