### PR TITLE
perf(handlers): optimize string-buffer reallocations

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -1196,9 +1196,9 @@ impl GraphicalReportHandler {
         let mut column = context_data.column();
         let mut offset = context_data.span().offset();
         let mut line_offset = offset;
+        let mut line_str = String::with_capacity(context.len());
+        let mut lines = Vec::with_capacity(1);
         let mut iter = context.chars().peekable();
-        let mut line_str = String::new();
-        let mut lines = Vec::new();
         while let Some(char) = iter.next() {
             offset += char.len_utf8();
             let mut at_end_of_file = false;

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -295,9 +295,9 @@ impl NarratableReportHandler {
         let mut column = context_data.column();
         let mut offset = context_data.span().offset();
         let mut line_offset = offset;
+        let mut line_str = String::with_capacity(context.len());
+        let mut lines = Vec::with_capacity(1);
         let mut iter = context.chars().peekable();
-        let mut line_str = String::new();
-        let mut lines = Vec::new();
         while let Some(char) = iter.next() {
             offset += char.len_utf8();
             let mut at_end_of_file = false;


### PR DESCRIPTION
This improves `get_lines()` logic by using a string-buffer with a capacity hint. That avoids growing the buffer from zero each time, saving a bunch of reallocations.

This is a forwarded patch from https://github.com/oxc-project/oxc/pull/3897, see there for further explanations and datapoints.