### PR TITLE
fix(graphical): format entire link instead of just name

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -568,13 +568,16 @@ impl GraphicalReportHandler {
         };
 
         if let Some(source_name) = primary_contents.name() {
-            let source_name = source_name.style(self.theme.styles.link);
             writeln!(
                 f,
-                "[{}:{}:{}]",
-                source_name,
-                primary_contents.line() + 1,
-                primary_contents.column() + 1
+                "[{}]",
+                format_args!(
+                    "{}:{}:{}",
+                    source_name,
+                    primary_contents.line() + 1,
+                    primary_contents.column() + 1
+                )
+                .style(self.theme.styles.link)
             )?;
         } else if lines.len() <= 1 {
             writeln!(f, "{}", self.theme.characters.hbar.to_string().repeat(3))?;


### PR DESCRIPTION
With the existing formatting, VSCode doesn't like to group the line and column with the link. You can check this with:

```sh
echo -e '-[\e[1m./README.md\e[0m:1:2]'
```

This is arguably a VSCode bug, but I think it makes sense to format the entire `name:line:col`, both logically and to ensure maximum compatibility with various terminal emulators.