### PR TITLE
Implement `Diagnostic` for `Infallible`

### DIFF
--- a/src/diagnostic_impls.rs
+++ b/src/diagnostic_impls.rs
@@ -2,45 +2,41 @@
 Default trait implementations for [`Diagnostic`].
 */
 
-use std::{convert::Infallible, fmt::Display, hint::unreachable_unchecked};
+use std::{convert::Infallible, fmt::Display};
 
 use crate::{Diagnostic, LabeledSpan, Severity, SourceCode};
 
-// Since all trait methods for [`Diagnostic`] take a reference to `self`, there must be an instance of `Self`.
-// However, since an instance of [`Infallible`] can never be constructed, these methods can never be called.
-// Therefore, these methods are unreachable, and can be safely optimized away by the compiler.
-#[allow(clippy::undocumented_unsafe_blocks)]
 impl Diagnostic for Infallible {
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn severity(&self) -> Option<Severity> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
-        unsafe { unreachable_unchecked() }
+        match *self {}
     }
 }
 

--- a/src/diagnostic_impls.rs
+++ b/src/diagnostic_impls.rs
@@ -1,0 +1,59 @@
+/*!
+Default trait implementations for [`Diagnostic`].
+*/
+
+use std::{convert::Infallible, fmt::Display, hint::unreachable_unchecked};
+
+use crate::{Diagnostic, LabeledSpan, Severity, SourceCode};
+
+// Since all trait methods for [`Diagnostic`] take a reference to `self`, there must be an instance of `Self`.
+// However, since an instance of [`Infallible`] can never be constructed, these methods can never be called.
+// Therefore, these methods are unreachable, and can be safely optimized away by the compiler.
+#[allow(clippy::undocumented_unsafe_blocks)]
+impl Diagnostic for Infallible {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn severity(&self) -> Option<Severity> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        unsafe { unreachable_unchecked() }
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        unsafe { unreachable_unchecked() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Report;
+
+    /// Test that [`Infallible`] implements [`Diagnostic`] by seeing if a function that's generic over `Diagnostic`
+    /// will accept `Infallible` as a type parameter.
+    #[test]
+    fn infallible() {
+        let _ = Report::new::<Infallible>;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,6 +788,7 @@ pub use protocol::*;
 
 mod chain;
 mod diagnostic_chain;
+mod diagnostic_impls;
 mod error;
 mod eyreish;
 #[cfg(feature = "fancy-base")]


### PR DESCRIPTION
I've been working with some code that looks like this:

```rust
trait DiagnosticTryFrom<Input>: Sized {
  type Error: Diagnostic;

  fn try_from_diagnostic(input: Input) -> Result<Self, Self::Error>;
}
```

And so logically it makes sense to create a blanket implementation on top of `TryInto`:

```rust
impl <I, O> DiagnosticTryFrom<I> for O where O: TryFrom<I>, O::Error: Diagnostic {
  type Error = O::Error;

  fn try_from_diagnostic(input: I) -> Result<Self, Self::Error> {
    O::try_from(input)
  }
}
```

Which works very well for my own `TryFrom` implementations -- but not so well when there's a `From` implementation available. Every `From` implementation [gets a blanket implementation of `TryFrom` with an error type of `Infallible`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html#generic-implementations), so I'm not able to implement `Diagnostic` for that error type due to the orphan rule.

This PR implements `Diagnostic` for `Infallible`, so any API relying on `TryFrom<T, Error: Diagnostic>` can also use `From<T>` implementations.
