### PR TITLE
feat: add `from_err()` method to `Report`

### DIFF
--- a/src/eyreish/error.rs
+++ b/src/eyreish/error.rs
@@ -425,6 +425,14 @@ impl Report {
         }
         .into()
     }
+
+    /// Construct a [`Report`] directly from an error-like type
+    pub fn from_err<E>(err: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        super::DiagnosticError(Box::new(err)).into()
+    }
 }
 
 impl<E> From<E> for Report

--- a/src/eyreish/into_diagnostic.rs
+++ b/src/eyreish/into_diagnostic.rs
@@ -6,7 +6,7 @@ use crate::{Diagnostic, Report};
 /// Errors. This is intended to be paired with [`IntoDiagnostic`].
 #[derive(Debug, Error)]
 #[error(transparent)]
-struct DiagnosticError(Box<dyn std::error::Error + Send + Sync + 'static>);
+pub(crate) struct DiagnosticError(pub(crate) Box<dyn std::error::Error + Send + Sync + 'static>);
 impl Diagnostic for DiagnosticError {}
 
 /**


### PR DESCRIPTION
There's no nice way to construct a bare `Report` from a regular `Error` type. You can construct `Result<_, Report>` from `Result::<_, E: ...>`, but not from an error by itself.

My workaround where `e: impl Error + Send + Sync + 'static` is to do `Err::<(), _>(e).into_diagnostic().unwrap_err()`, which obviously is ugly.

I added a `Report::from_err()` method that solves this problem in the same way as the `IntoDiagnostic` trait, by using its `DiagnosticError` type.