### PR TITLE
fix(clippy): Fix `needless_return` lint.

### DIFF
--- a/src/highlighters/mod.rs
+++ b/src/highlighters/mod.rs
@@ -92,7 +92,7 @@ impl Default for MietteHighlighter {
     }
     #[cfg(not(feature = "syntect-highlighter"))]
     fn default() -> Self {
-        return MietteHighlighter::nocolor();
+        MietteHighlighter::nocolor()
     }
 }
 


### PR DESCRIPTION
This happens when building with `--features fancy`.