### PR TITLE
Allow SpanContents to possibly own its backing data

### DIFF
--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -165,7 +165,7 @@ impl NarratableReportHandler {
                         .map(|label| {
                             source.read_span(label.inner(), self.context_lines, self.context_lines)
                         })
-                        .collect::<Result<Vec<Box<dyn SpanContents<'_>>>, MietteError>>()
+                        .collect::<Result<Vec<Box<dyn SpanContents>>, MietteError>>()
                         .map_err(|_| fmt::Error)?;
                     let mut contexts = Vec::new();
                     for (right, right_conts) in labels.iter().cloned().zip(contents.iter()) {
@@ -286,7 +286,7 @@ impl NarratableReportHandler {
         &'a self,
         source: &'a dyn SourceCode,
         context_span: &'a SourceSpan,
-    ) -> Result<(Box<dyn SpanContents<'a> + 'a>, Vec<Line>), fmt::Error> {
+    ) -> Result<(Box<dyn SpanContents + 'a>, Vec<Line>), fmt::Error> {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -252,7 +252,7 @@ pub trait SourceCode: Send + Sync {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError>;
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError>;
 }
 
 /// A labeled [`SourceSpan`].
@@ -434,9 +434,9 @@ Contents of a [`SourceCode`] covered by [`SourceSpan`].
 
 Includes line and column information to optimize highlight calculations.
 */
-pub trait SpanContents<'a> {
+pub trait SpanContents {
     /// Reference to the data inside the associated span, in bytes.
-    fn data(&self) -> &'a [u8];
+    fn data(&self) -> &[u8];
     /// [`SourceSpan`] representing the span covered by this `SpanContents`.
     fn span(&self) -> &SourceSpan;
     /// An optional (file?) name for the container of this `SpanContents`.
@@ -530,8 +530,8 @@ impl<'a> MietteSpanContents<'a> {
     }
 }
 
-impl<'a> SpanContents<'a> for MietteSpanContents<'a> {
-    fn data(&self) -> &'a [u8] {
+impl<'a> SpanContents for MietteSpanContents<'a> {
+    fn data(&self) -> &[u8] {
         self.data
     }
     fn span(&self) -> &SourceSpan {

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -98,7 +98,7 @@ impl SourceCode for [u8] {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         let contents = context_info(self, span, context_lines_before, context_lines_after)?;
         Ok(Box::new(contents))
     }
@@ -110,7 +110,7 @@ impl<'src> SourceCode for &'src [u8] {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -121,7 +121,7 @@ impl SourceCode for Vec<u8> {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -132,7 +132,7 @@ impl SourceCode for str {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         <[u8] as SourceCode>::read_span(
             self.as_bytes(),
             span,
@@ -149,7 +149,7 @@ impl<'s> SourceCode for &'s str {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -160,7 +160,7 @@ impl SourceCode for String {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -171,7 +171,7 @@ impl<T: ?Sized + SourceCode> SourceCode for Arc<T> {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         self.as_ref()
             .read_span(span, context_lines_before, context_lines_after)
     }
@@ -191,7 +191,7 @@ where
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<Box<dyn SpanContents + 'a>, MietteError> {
         self.as_ref()
             .read_span(span, context_lines_before, context_lines_after)
     }


### PR DESCRIPTION
This is accomplished by removing the lifetime parameter on the `SpanContents` trait. (addresses #410)

Up to authors/maintainers whether to merge this or not, here's some pros and cons for this approach:
### Pros:
* makes `SpanContents` much more flexible, as it is no longer forced to borrow its data from the corresponding `SourceCode`.
* forces any wrapper types to actually wrap the inner `SpanContents`, as opposed to taking its data reference, calling the getters once and constructing a new `MietteSpanContents<'data>`. This probably doesn't matter *that* much, but it is technically possible to create a weird `SpanContents` implementation that does not return consistent values from its getters, which the current implementation of `NamedSource` does not handle correctly.

### Cons:
* Makes `NamedSource` and some user-defined `SpanContents` wrappers slightly less efficient. As discussed above, `NamedSource` and other user-defined wrappers are now forced to retain the inner `SpanContents` instead of copying the relevant data out of it, requiring the addition of an indirection if the inner `SpanContents`' type is not statically known. In practice many such usages will retain similar performance (at least in release builds) due to vtable inlining, but the fact remains that this change will result in equivalent or worse performance.
* This is a breaking change, requiring the user to make major changes if they wrap `SpanContents` in a way similar to the current implementation of `NamedSource` (see the changes to `NamedSource` for an example of what this entails)

#### Errata
* Is `NamedSource` intended to override the language all the time, or only when `language` is not `None`? (the previous behavior is all of the time but this feels like the wrong behavior)