### PR TITLE
Add required bounds to derived impl

### DIFF
--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
-syn = "2.0.48"
+syn = { version = "2.0.48", features = ["extra-traits"] }

--- a/miette-derive/src/diagnostic_source.rs
+++ b/miette-derive/src/diagnostic_source.rs
@@ -3,6 +3,7 @@ use quote::quote;
 use syn::spanned::Spanned;
 
 use crate::forward::WhichFn;
+use crate::trait_bounds::TraitBoundStore;
 use crate::{
     diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
     utils::{display_pat_members, gen_all_variants_with},
@@ -11,17 +12,25 @@ use crate::{
 pub struct DiagnosticSource(syn::Member);
 
 impl DiagnosticSource {
-    pub(crate) fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
+    pub(crate) fn from_fields(
+        fields: &syn::Fields,
+        bounds_store: &mut TraitBoundStore,
+    ) -> syn::Result<Option<Self>> {
         match fields {
-            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
+            syn::Fields::Named(named) => {
+                Self::from_fields_vec(named.named.iter().collect(), bounds_store)
+            }
             syn::Fields::Unnamed(unnamed) => {
-                Self::from_fields_vec(unnamed.unnamed.iter().collect())
+                Self::from_fields_vec(unnamed.unnamed.iter().collect(), bounds_store)
             }
             syn::Fields::Unit => Ok(None),
         }
     }
 
-    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
+    fn from_fields_vec(
+        fields: Vec<&syn::Field>,
+        bounds_store: &mut TraitBoundStore,
+    ) -> syn::Result<Option<Self>> {
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("diagnostic_source") {
@@ -33,6 +42,9 @@ impl DiagnosticSource {
                             span: field.span(),
                         })
                     };
+
+                    bounds_store.register_source_usage(&field.ty);
+
                     return Ok(Some(DiagnosticSource(diagnostic_source)));
                 }
             }

--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -156,11 +156,11 @@ impl Labels {
 
                     match lbl_ty {
                         LabelType::Default | LabelType::Primary => {
-                            bounds_store.register_source_span_usage(&field.ty);
+                            bounds_store.register_label_usage(&field.ty);
                         }
 
                         LabelType::Collection => {
-                            bounds_store.register_source_span_collection_usage(&field.ty);
+                            bounds_store.register_label_collection_usage(&field.ty);
                         }
                     }
 
@@ -207,9 +207,10 @@ impl Labels {
 
             Some(quote! {
                 miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(&self.#span)
+                .as_ref()
                 .map(|#var| #ctor(
                     #display,
-                    #var.clone(),
+                    (*#var).clone(),
                 ))
             })
         });
@@ -229,10 +230,11 @@ impl Labels {
             } else {
                 quote! { std::option::Option::None }
             };
+
             Some(quote! {
                 .chain({
                     let display = #display;
-                    self.#span.iter().map(move |span| {
+                    ::std::iter::IntoIterator::into_iter(&self.#span).map(move |span| {
                         use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
                         let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
                         if display.is_some() && labeled_span.label().is_none() {

--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -210,7 +210,7 @@ impl Labels {
                 .as_ref()
                 .map(|#var| #ctor(
                     #display,
-                    (*#var).clone(),
+                    (*#var).to_owned(),
                 ))
             })
         });
@@ -236,7 +236,7 @@ impl Labels {
                     let display = #display;
                     ::std::iter::IntoIterator::into_iter(&self.#span).map(move |span| {
                         use miette::macro_helpers::{ToLabelSpanWrapper,ToLabeledSpan};
-                        let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.clone());
+                        let mut labeled_span = ToLabelSpanWrapper::to_labeled_span(span.to_owned());
                         if display.is_some() && labeled_span.label().is_none() {
                             labeled_span.set_label(display.clone())
                         }

--- a/miette-derive/src/lib.rs
+++ b/miette-derive/src/lib.rs
@@ -14,6 +14,7 @@ mod label;
 mod related;
 mod severity;
 mod source_code;
+mod trait_bounds;
 mod url;
 mod utils;
 

--- a/miette-derive/src/source_code.rs
+++ b/miette-derive/src/source_code.rs
@@ -37,33 +37,7 @@ impl SourceCode {
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("source_code") {
-                    let is_option = if let syn::Type::Path(syn::TypePath {
-                        path: syn::Path { segments, .. },
-                        ..
-                    }) = &field.ty
-                    {
-                        segments
-                            .last()
-                            .filter(|seg| seg.ident == "Option")
-                            .and_then(|seg| match &seg.arguments {
-                                PathArguments::AngleBracketed(AngleBracketedGenericArguments {
-                                    args,
-                                    ..
-                                }) => {
-                                    let mut iter = args.iter();
-
-                                    let ty = iter.next();
-                                    iter.next().xor(ty)
-                                }
-                                _ => None,
-                            })
-                            .and_then(|arg| match arg {
-                                GenericArgument::Type(ty) => Some(ty),
-                                _ => None,
-                            })
-                    } else {
-                        None
-                    };
+                    let is_option = TraitBoundStore::extract_option(&field.ty);
 
                     if let Some(option_ty) = is_option {
                         bounds_store.register_source_code_usage(option_ty);

--- a/miette-derive/src/trait_bounds.rs
+++ b/miette-derive/src/trait_bounds.rs
@@ -1,0 +1,341 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    iter::{once, FromIterator},
+};
+
+use proc_macro2::Span;
+use syn::{
+    punctuated::Punctuated, token::Plus, AngleBracketedGenericArguments, AssocType,
+    GenericArgument, GenericParam, Generics, ParenthesizedGenericArguments, Path, PathArguments,
+    PathSegment, PredicateType, ReturnType, Token, Type, TypeArray, TypeGroup, TypeParamBound,
+    TypeParen, TypePath, TypePtr, TypeReference, TypeSlice, TypeTuple, WhereClause, WherePredicate,
+};
+
+#[derive(Default)]
+pub struct RequiredTraitBound {
+    r#static: bool,
+    std_error: bool,
+    miette_diagnostic: bool,
+    source_code: bool,
+    into_source_span: bool,
+    std_into_iter: bool,
+}
+
+impl RequiredTraitBound {
+    fn to_bounds(&self) -> Punctuated<TypeParamBound, Plus> {
+        let mut bounds = Punctuated::new();
+        if self.std_error && !self.miette_diagnostic {
+            bounds.push(TypeParamBound::Trait(syn::parse_quote!(
+                ::std::error::Error
+            )));
+        }
+
+        if self.miette_diagnostic {
+            bounds.push(TypeParamBound::Trait(syn::parse_quote!(
+                ::miette::Diagnostic
+            )))
+        }
+
+        if self.source_code {
+            bounds.push(TypeParamBound::Trait(syn::parse_quote!(
+                ::miette::SourceCode
+            )))
+        }
+
+        if self.into_source_span {
+            bounds.push(TypeParamBound::Trait(syn::parse_quote!(
+                ::std::convert::Into<::miette::SourceSpan>
+            )))
+        }
+
+        if self.std_into_iter {
+            bounds.push(TypeParamBound::Trait(syn::parse_quote!(
+                ::std::iter::IntoIterator
+            )))
+        }
+
+        if self.r#static {
+            bounds.push(TypeParamBound::Lifetime(syn::parse_quote!('static)))
+        }
+
+        bounds
+    }
+
+    fn register_transparent_usage(&mut self) {
+        self.r#static = true;
+        self.miette_diagnostic = true;
+    }
+
+    fn register_source_code_usage(&mut self) {
+        self.source_code = true;
+    }
+
+    fn register_source_span_usage(&mut self) {
+        self.into_source_span = true;
+    }
+
+    fn register_collection_usage(&mut self) {
+        self.std_into_iter = true;
+    }
+    fn register_related_item_usage(&mut self) {
+        self.miette_diagnostic = true;
+        self.r#static = true;
+    }
+
+    fn register_source_usage(&mut self) {
+        self.miette_diagnostic = true;
+        self.r#static = true;
+    }
+}
+
+pub struct TraitBoundStore(HashMap<Type, RequiredTraitBound>);
+
+impl TraitBoundStore {
+    pub fn new(generics: &Generics) -> Self {
+        let hash_map = generics
+            .params
+            .iter()
+            .filter_map(|param| {
+                if let GenericParam::Type(ty) = param {
+                    Some(ty)
+                } else {
+                    None
+                }
+            })
+            .map(|param| {
+                Type::Path(TypePath {
+                    qself: None,
+                    path: Path {
+                        leading_colon: None,
+                        segments: Punctuated::from_iter(once(PathSegment {
+                            ident: param.ident.clone(),
+                            arguments: PathArguments::None,
+                        })),
+                    },
+                })
+            })
+            .map(|v| (v, RequiredTraitBound::default()))
+            .collect::<HashMap<_, _>>();
+
+        Self(hash_map)
+    }
+
+    fn check_generic_usage<'ty>(&self, mut r#type: &'ty Type) -> Option<&'ty Type> {
+        // in theory we could skip all this logic and just allow trivial bounds but that would add redundant trait bounds
+        // to the derived impl - would be another choice to make. I choose to filter as much as possible so that we don't
+        // introduce unneccessary bounds.
+
+        // this reduces the type down as much as possible to remove unneeded groups.
+        let original_type = loop {
+            match r#type {
+                Type::Paren(TypeParen { elem, .. }) => r#type = &**elem,
+                Type::Group(TypeGroup { elem, .. }) => r#type = &**elem,
+                x => break x,
+            }
+        };
+
+        let mut depends_on_generic = false;
+
+        // max depth to check, after which we'll just add the (maybe redundant) bound anyways.
+        // this is a tradeoff between filtering speed and compiler speed so I'll keep it
+        // reasonably low for now, since I assume the compiler is better optimized for more complex
+        // checks.
+        let max_depth = 8;
+
+        let mut to_check_queue: VecDeque<(&Type, usize)> = VecDeque::new();
+        to_check_queue.push_back((original_type, 0));
+
+        while !depends_on_generic {
+            // this needs to be like this cuz if-let-chains aren't supported yet
+            let Some((elem, current_depth)) = to_check_queue.pop_front() else {
+                break;
+            };
+
+            // if we exceed the max depth we just assume it depends on the generic and let the compiler check it
+            if current_depth > max_depth {
+                depends_on_generic = true;
+                break;
+            }
+
+            // the map contains types that we know depend on generics so we can just short circuit
+            //
+            // this is also the "bottom" check since we add the generics themselves to the map when
+            // constructing self
+            if self.0.contains_key(elem) {
+                depends_on_generic = true;
+                break;
+            }
+
+            // basically go through the type and add all referenced types inside it to the check queue
+            match elem {
+                Type::Group(_) => unreachable!("This is unwrapped above"),
+                Type::Paren(_) => unreachable!("This is unwrapped above"),
+                // function pointer's can never implement the required trait bounds anyways so we just accept the errors
+                Type::BareFn(_) => return None,
+                // impl trait types aren't allowed from struct/enum definitions anyways so we can just ignore them
+                Type::ImplTrait(_) => return None,
+                // infered types aren't allowed either
+                Type::Infer(_) => return None,
+                // macros are opaque to us and i don't really know how to properly implement this.
+                // we could in theory I think introduce a type alias and use that instead but honestly
+                // type macros are such a niche usecase especially in combination with a generic,
+                // I would say we should just recommend to implement
+                // the trait manually, as such we just accept the error if any occurs (this still allows using macros when they
+                // return concrete types which don't depend on any generic or when the generic doesn't affect the
+                // required trait implementation)
+                Type::Macro(_) => return None,
+                // trait objects which depend on a generic inside them seem like very much a hassle to implement so i'll ignore
+                // them for now, if the need arises we could support that in a future pr maybe?
+                //
+                // this again doesn't restrict the usage of trait objects which implement the required traits regardless of the generics.
+                Type::TraitObject(_) => return None,
+                // Well never is never and never never.
+                Type::Never(_) => return None,
+                Type::Array(TypeArray { elem, .. })
+                | Type::Ptr(TypePtr { elem, .. })
+                | Type::Reference(TypeReference { elem, .. })
+                | Type::Slice(TypeSlice { elem, .. }) => {
+                    to_check_queue.push_back((&**elem, current_depth + 1));
+                }
+                Type::Path(TypePath { qself, path }) => {
+                    if let Some(qself) = qself {
+                        to_check_queue.push_back((&qself.ty, current_depth + 1));
+                    }
+
+                    for segment in &path.segments {
+                        match &segment.arguments {
+                            PathArguments::None => {}
+                            PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                                args,
+                                ..
+                            }) => {
+                                for argument in args {
+                                    match argument {
+                                        GenericArgument::Type(ty)
+                                        | GenericArgument::AssocType(AssocType { ty, .. }) => {
+                                            to_check_queue.push_back((ty, current_depth + 1));
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            PathArguments::Parenthesized(ParenthesizedGenericArguments {
+                                inputs,
+                                output,
+                                ..
+                            }) => {
+                                for inp in inputs {
+                                    to_check_queue.push_back((inp, current_depth + 1));
+                                }
+
+                                if let ReturnType::Type(_, ty) = output {
+                                    to_check_queue.push_back((ty, current_depth + 1));
+                                }
+                            }
+                        }
+                    }
+                }
+                Type::Tuple(TypeTuple { elems, .. }) => {
+                    for elem in elems {
+                        to_check_queue.push_back((elem, current_depth + 1));
+                    }
+                }
+                // we can't really handle verbatim so we just assume it depends on the generics
+                Type::Verbatim(_) => depends_on_generic = true,
+                _ => depends_on_generic = true,
+            }
+        }
+
+        depends_on_generic.then_some(original_type)
+    }
+
+    pub fn merge_with(&self, where_clause: Option<&WhereClause>) -> Option<WhereClause> {
+        if self.0.is_empty() {
+            return where_clause.cloned();
+        }
+
+        let mut where_clause = where_clause.cloned().unwrap_or_else(|| WhereClause {
+            where_token: Token![where](Span::mixed_site()),
+            predicates: Punctuated::new(),
+        });
+
+        where_clause
+            .predicates
+            .extend(self.0.iter().map(|(ty, bounds)| {
+                WherePredicate::Type(PredicateType {
+                    lifetimes: None,
+                    bounded_ty: ty.clone(),
+                    colon_token: Token![:](Span::mixed_site()),
+                    bounds: bounds.to_bounds(),
+                })
+            }));
+
+        Some(where_clause)
+    }
+
+    pub fn register_transparent_usage(&mut self, r#type: &Type) {
+        let Some(r#type) = self.check_generic_usage(r#type) else {
+            return;
+        };
+
+        let type_opts = self.0.entry(r#type.clone()).or_default();
+        type_opts.register_transparent_usage()
+    }
+
+    pub fn register_source_code_usage(&mut self, r#type: &Type) {
+        let Some(r#type) = self.check_generic_usage(r#type) else {
+            return;
+        };
+
+        let type_opts = self.0.entry(r#type.clone()).or_default();
+        type_opts.register_source_code_usage()
+    }
+
+    pub fn register_source_span_usage(&mut self, r#type: &Type) {
+        let Some(r#type) = self.check_generic_usage(r#type) else {
+            return;
+        };
+
+        let type_opts = self.0.entry(r#type.clone()).or_default();
+        type_opts.register_source_span_usage()
+    }
+
+    pub fn register_source_span_collection_usage(&mut self, r#type: &Type) {
+        let Some(ty) = self.check_generic_usage(r#type) else {
+            return;
+        };
+
+        let type_opts = self.0.entry(ty.clone()).or_default();
+        type_opts.register_collection_usage();
+
+        let type_opts_item = self
+            .0
+            .entry(syn::parse_quote!(<#ty as ::std::iter::IntoIterator>::Item))
+            .or_default();
+        type_opts_item.register_source_span_usage();
+    }
+
+    pub fn register_related_usage(&mut self, r#type: &Type) {
+        let Some(ty) = self.check_generic_usage(r#type) else {
+            return;
+        };
+
+        let type_opts = self.0.entry(ty.clone()).or_default();
+        type_opts.register_collection_usage();
+
+        let type_opts_item = self
+            .0
+            .entry(syn::parse_quote!(<#ty as ::std::iter::IntoIterator>::Item))
+            .or_default();
+        type_opts_item.register_related_item_usage();
+    }
+
+    pub(crate) fn register_source_usage(&mut self, r#type: &Type) {
+        let Some(ty) = self.check_generic_usage(r#type) else {
+            return;
+        };
+
+        let type_opts = self.0.entry(ty.clone()).or_default();
+        type_opts.register_source_usage();
+    }
+}

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -217,6 +217,8 @@ fn fmt_help() {
         #[diagnostic(code(foo::x), help("{} x {len} x {:?}", 1, "2"))]
         Y { len: usize },
 
+        // for some reason rust analyzer has a false positive with the self = self in the format!
+        // here but it compiles and tests just fine. (02/02/2025)
         #[diagnostic(code(foo::x), help("{} x {self:?} x {:?}", 1, "2"))]
         Z,
     }

--- a/tests/test_derive_attr.rs
+++ b/tests/test_derive_attr.rs
@@ -145,3 +145,133 @@ fn attr_not_required() {
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
     assert_eq!(err_span, expectation);
 }
+
+fn assert_impl_diagnostic<T: Diagnostic>() {}
+
+#[test]
+fn transparent_generic() {
+    #[derive(Debug, Diagnostic, Error)]
+    enum Combined<T> {
+        #[error(transparent)]
+        #[diagnostic(transparent)]
+        Other(T),
+        #[error("foo")]
+        Custom,
+    }
+
+    assert_impl_diagnostic::<Combined<miette::MietteDiagnostic>>();
+}
+
+#[test]
+fn generic_label() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[label]
+        label: T,
+    }
+
+    assert_impl_diagnostic::<Combined<SourceSpan>>();
+    assert_impl_diagnostic::<Combined<(usize, usize)>>();
+}
+
+#[test]
+fn generic_source_code() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[source_code]
+        label: T,
+    }
+
+    assert_impl_diagnostic::<Combined<String>>();
+}
+
+#[test]
+fn generic_optional_source_code() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[source_code]
+        label: Option<T>,
+    }
+
+    assert_impl_diagnostic::<Combined<String>>();
+}
+
+#[test]
+fn generic_label_primary() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[label(primary)]
+        label: T,
+    }
+
+    assert_impl_diagnostic::<Combined<SourceSpan>>();
+    assert_impl_diagnostic::<Combined<(usize, usize)>>();
+}
+
+#[test]
+fn generic_label_collection() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[label(collection)]
+        label: Vec<T>,
+    }
+
+    assert_impl_diagnostic::<Combined<SourceSpan>>();
+    assert_impl_diagnostic::<Combined<(usize, usize)>>();
+}
+
+#[test]
+fn generic_label_generic_collection() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[label(collection)]
+        label: T,
+    }
+
+    assert_impl_diagnostic::<Combined<Vec<SourceSpan>>>();
+    assert_impl_diagnostic::<Combined<Vec<(usize, usize)>>>();
+}
+
+#[test]
+fn generic_related() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("foo")]
+    struct Combined<T> {
+        #[related]
+        label: Vec<T>,
+    }
+
+    assert_impl_diagnostic::<Combined<miette::MietteDiagnostic>>();
+}
+
+#[test]
+fn generic_diagnostic_source() {
+    #[derive(Debug, Diagnostic, Error)]
+    enum Combined<T> {
+        #[error(transparent)]
+        Other(#[diagnostic_source] T),
+        #[error("foo")]
+        Custom,
+    }
+
+    assert_impl_diagnostic::<Combined<miette::MietteDiagnostic>>();
+}
+
+#[test]
+fn generic_not_influencing_default() {
+    #[derive(Debug, Diagnostic, Error)]
+    enum Combined<T> {
+        #[error("bar")]
+        Other(T),
+        #[error("foo")]
+        Custom,
+    }
+
+    assert_impl_diagnostic::<Combined<i32>>();
+}


### PR DESCRIPTION
This is an attempt to make the derive macro for `Diagnostic` work better with generics, allowing to write code like for example


```rust
#[derive(Debug, thiserror::Error, miette::Diagnostic)
enum MyError<T> {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Other(#[from] T).
     #[error("bar")]
     #[diagnostic(help = "baz")]
     Foo
}
```

This should for example make #162 just work, as well as things like


```rust
#[derive(Debug, thiserror::Error, miette::Diagnostic)
struct MyOtherError<T> {
     #[label]
     label: T
}
``` 

and the other supported attributes.

AFAIK the only gotcha with this implementation right now is that `#[related]` only works with concrete collection types and not with generic collections, but the type inside the collection can be generic. (meaning: `Vec<T>` works but not any arbitrary `C` where `C: IntoIter<Item: Diagnostic>`), and I think that is a current limitation of the rust compiler / the current Diagnostic trait design.

Questions: Do we want to gate this behind a feature flag since it pulls in extra-traits from syn and performs a bunch of extra work?