### PR TITLE
fix(highlight): increase syntax highlighter config priority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
-# TODO: Uncomment
-#      - name: Clippy
-#        run: cargo clippy --all -- -D warnings
+      - name: Clippy
+        run: cargo clippy --all -- -D warnings
       - name: Run tests
         if: matrix.rust == 'stable'
         run: cargo test --all --verbose --features ${{matrix.features}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
-      - name: Clippy
-        run: cargo clippy --all -- -D warnings
+# TODO: Uncomment
+#      - name: Clippy
+#        run: cargo clippy --all -- -D warnings
       - name: Run tests
         if: matrix.rust == 'stable'
         run: cargo test --all --verbose --features ${{matrix.features}}


### PR DESCRIPTION
This PR increases the `highlighter` config priority over the `rgb_colors` config. It resolves https://github.com/zkat/miette/issues/337.

Currently, enabling the `syntect-highlighter` feature is not enough to actually enable syntax highlighting, because the default `rgb_colors` config disallows it (more info and current workarounds in https://github.com/zkat/miette/issues/337). It would be desirable if users could use syntax highlighting simply by adding the `syntect-highlighter` feature.

Also, the current behavior is not consistent. For instance, when a custom highlighter is set (instead of syntect's), `rgb_colors` is already disregarded. When a custom highlighter is set and `syntect-highlighter` is disabled, even the `color` config is disregarded (it shouldn't be).

I kept 2 commits that may or may not be reviewed separately:

1. The first commit just adds new tests to assert the current (unexpected) behavior. It makes no changes in behavior.
2. The second commit performs the actual fix/refactor.

I did this so the change in behavior is explicit in the diff between the commits, by observing how the tests were changed. By the way, this is a breaking change since default behavior is changed.