### PR TITLE
update `thiserror` from 1.0.56 to 2.0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures = { version = "0.3", default-features = false }
 indenter = "0.3.3"
 rustversion = "1.0"
 trybuild = { version = "1.0.89", features = ["diff"] }
-syn = { version = "2.0.48", features = ["full"] }
+syn = { version = "2.0.87", features = ["full"] }
 regex = "1.10"
 lazy_static = "1.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.70.0"
 exclude = ["images/", "tests/", "miette-derive/"]
 
 [dependencies]
-thiserror = "1.0.56"
+thiserror = "2.0.11"
 miette-derive = { path = "miette-derive", version = "=7.5.0", optional = true }
 unicode-width = "0.1.11"
 cfg-if = "1.0.0"

--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/zkat/miette"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.78"
+proc-macro2 = "1.0.83"
 quote = "1.0.35"
-syn = "2.0.48"
+syn = "2.0.87"

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -26,7 +26,7 @@ pub fn set_panic_hook() {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("{0}{}", Panic::backtrace())]
+#[error("{0}{panic}", panic = Panic::backtrace())]
 #[diagnostic(help("set the `RUST_BACKTRACE=1` environment variable to display a backtrace."))]
 struct Panic(String);
 


### PR DESCRIPTION
Hello,

I'm using `watchexec`, which depends on `miette` and `thiserror 2.x`. `miette` currently depends on `thiserror 1.x`, which results in both versions being included in the dependency tree.

I ran `cargo test`, but I'm not sure if there's anything else I should check. Please let me know if there's anything else I need to do.

Thanks!