### PR TITLE
Remove `thiserror` from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.70.0"
 exclude = ["images/", "tests/", "miette-derive/"]
 
 [dependencies]
-thiserror = "2.0.11"
 miette-derive = { path = "miette-derive", version = "=7.5.0", optional = true }
 unicode-width = "0.1.11"
 cfg-if = "1.0.0"
@@ -30,6 +29,7 @@ serde = { version = "1.0.196", features = ["derive"], optional = true }
 syntect = { version = "5.1.0", optional = true }
 
 [dev-dependencies]
+thiserror = "2.0.11"
 semver = "1.0.21"
 
 # Eyre devdeps

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,7 @@ pub(crate) mod tests {
     use super::*;
 
     #[derive(Debug)]
-    pub struct TestError(pub io::Error);
+    pub(crate) struct TestError(pub io::Error);
 
     impl Display for TestError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,7 @@ pub(crate) mod tests {
     use super::*;
 
     #[derive(Debug)]
-    pub(crate) struct TestError(pub io::Error);
+    pub(crate) struct TestError(pub(crate) io::Error);
 
     impl Display for TestError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,7 +78,7 @@ impl Diagnostic for MietteError {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::error::Error;
+    use std::{error::Error, io::ErrorKind};
 
     use super::*;
 
@@ -99,9 +99,9 @@ pub(crate) mod tests {
 
     #[test]
     fn io_error() {
-        let inner_error = io::Error::other("halt and catch fire");
+        let inner_error = io::Error::new(ErrorKind::Other, "halt and catch fire");
         let outer_error = TestError(inner_error);
-        let io_error = io::Error::other(outer_error);
+        let io_error = io::Error::new(ErrorKind::Other, outer_error);
 
         let miette_error = MietteError::from(io_error);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,23 +1,42 @@
-use std::{fmt, io};
-
-use thiserror::Error;
+use std::{
+    error::Error,
+    fmt::{self, Display},
+    io,
+};
 
 use crate::Diagnostic;
 
 /**
 Error enum for miette. Used by certain operations in the protocol.
 */
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum MietteError {
     /// Wrapper around [`std::io::Error`]. This is returned when something went
     /// wrong while reading a [`SourceCode`](crate::SourceCode).
-    #[error(transparent)]
-    IoError(#[from] io::Error),
+    IoError(io::Error),
 
     /// Returned when a [`SourceSpan`](crate::SourceSpan) extends beyond the
     /// bounds of a given [`SourceCode`](crate::SourceCode).
-    #[error("The given offset is outside the bounds of its Source")]
     OutOfBounds,
+}
+
+impl Display for MietteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MietteError::IoError(error) => write!(f, "{error}"),
+            MietteError::OutOfBounds => {
+                write!(f, "The given offset is outside the bounds of its Source")
+            }
+        }
+    }
+}
+
+impl Error for MietteError {}
+
+impl From<io::Error> for MietteError {
+    fn from(value: io::Error) -> Self {
+        Self::IoError(value)
+    }
 }
 
 impl Diagnostic for MietteError {
@@ -47,5 +66,32 @@ impl Diagnostic for MietteError {
             "https://docs.rs/miette/{}/miette/enum.MietteError.html{}",
             crate_version, variant,
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn io_error() {
+        let io_error = io::Error::new(io::ErrorKind::Other, "halt and catch fire");
+        let miette_error = MietteError::from(io_error);
+
+        assert_eq!(miette_error.to_string(), "halt and catch fire");
+        assert_eq!(miette_error.source().map(ToString::to_string), None);
+    }
+
+    #[test]
+    fn out_of_bounds() {
+        let miette_error = MietteError::OutOfBounds;
+
+        assert_eq!(
+            miette_error.to_string(),
+            "The given offset is outside the bounds of its Source"
+        );
+        assert_eq!(miette_error.source().map(ToString::to_string), None);
     }
 }

--- a/src/eyreish/error.rs
+++ b/src/eyreish/error.rs
@@ -280,7 +280,7 @@ impl Report {
     /// The root cause is the last error in the iterator produced by
     /// [`chain()`](Report::chain).
     pub fn root_cause(&self) -> &(dyn StdError + 'static) {
-        self.chain().last().unwrap()
+        self.chain().next_back().unwrap()
     }
 
     /// Returns true if `E` is the type held by this error object.

--- a/src/eyreish/into_diagnostic.rs
+++ b/src/eyreish/into_diagnostic.rs
@@ -46,7 +46,7 @@ impl<T, E: std::error::Error + Send + Sync + 'static> IntoDiagnostic<T, E> for R
 
 #[cfg(test)]
 mod tests {
-    use std::io;
+    use std::io::{self, ErrorKind};
 
     use super::*;
 
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn diagnostic_error() {
-        let inner_error = io::Error::other("halt and catch fire");
+        let inner_error = io::Error::new(ErrorKind::Other, "halt and catch fire");
         let outer_error: Result<(), _> = Err(TestError(inner_error));
 
         let diagnostic_error = outer_error.into_diagnostic().unwrap_err();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -424,7 +424,7 @@ impl HighlighterOption {
         highlighter: Option<MietteHighlighter>,
         supports_color: bool,
     ) -> HighlighterOption {
-        if color == Some(false) || (color == None && !supports_color) {
+        if color == Some(false) || (color.is_none() && !supports_color) {
             return HighlighterOption::Disable;
         }
         highlighter
@@ -433,6 +433,9 @@ impl HighlighterOption {
     }
 }
 
+// NOTE: This is manually implemented so that it's clearer what's going on with
+// the conditional compilation — clippy isn't picking up the `cfg` stuff here
+#[allow(clippy::derivable_impls)]
 impl Default for HighlighterOption {
     fn default() -> Self {
         cfg_if! {

--- a/src/highlighters/syntect.rs
+++ b/src/highlighters/syntect.rs
@@ -96,12 +96,12 @@ impl SyntectHighlighter {
             }
         }
         // finally, attempt to guess syntax based on first line
-        return self.syntax_set.find_syntax_by_first_line(
+        self.syntax_set.find_syntax_by_first_line(
             std::str::from_utf8(contents.data())
                 .ok()?
                 .split('\n')
                 .next()?,
-        );
+        )
     }
 }
 
@@ -115,7 +115,7 @@ pub(crate) struct SyntectHighlighterState<'h> {
     use_bg_color: bool,
 }
 
-impl<'h> HighlighterState for SyntectHighlighterState<'h> {
+impl HighlighterState for SyntectHighlighterState<'_> {
     fn highlight_line<'s>(&mut self, line: &'s str) -> Vec<Styled<&'s str>> {
         if let Ok(ops) = self.parse_state.parse_line(line, self.syntax_set) {
             let use_bg_color = self.use_bg_color;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 //!   - [... handler options](#-handler-options)
 //!   - [... dynamic diagnostics](#-dynamic-diagnostics)
 //!   - [... syntax highlighting](#-syntax-highlighting)
+//!   - [... primary label](#-primary-label)
 //!   - [... collection of labels](#-collection-of-labels)
 //! - [Acknowledgements](#acknowledgements)
 //! - [License](#license)
@@ -689,6 +690,37 @@
 //! trait to [`MietteHandlerOpts`] by calling the
 //! [`with_syntax_highlighting`](MietteHandlerOpts::with_syntax_highlighting)
 //! method. See the [`highlighters`] module docs for more details.
+//!
+//! ### ... primary label
+//!
+//! You can use the `primary` parameter to `label` to indicate that the label
+//! is the primary label.
+//!
+//! ```rust,ignore
+//! #[derive(Debug, Diagnostic, Error)]
+//! #[error("oops!")]
+//! struct MyError {
+//!     #[label(primary, "main issue")]
+//!     primary_span: SourceSpan,
+//!
+//!     #[label("other label")]
+//!     other_span: SourceSpan,
+//! }
+//! ```
+//!
+//! The `primary` parameter can be used at most once:
+//!
+//! ```rust,ignore
+//! #[derive(Debug, Diagnostic, Error)]
+//! #[error("oops!")]
+//! struct MyError {
+//!     #[label(primary, "main issue")]
+//!     primary_span: SourceSpan,
+//!
+//!     #[label(primary, "other label")] // Error: Cannot have more than one primary label.
+//!     other_span: SourceSpan,
+//! }
+//! ```
 //!
 //! ### ... collection of labels
 //!

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -12,7 +12,7 @@ use std::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::MietteError;
+use crate::{DiagnosticError, MietteError};
 
 /// Adds rich metadata to your Error that can be used by
 /// [`Report`](crate::Report) to print really nice and human-friendly error
@@ -174,18 +174,7 @@ impl From<String> for Box<dyn Diagnostic + Send + Sync> {
 
 impl From<Box<dyn std::error::Error + Send + Sync>> for Box<dyn Diagnostic + Send + Sync> {
     fn from(s: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        #[derive(thiserror::Error)]
-        #[error(transparent)]
-        struct BoxedDiagnostic(Box<dyn std::error::Error + Send + Sync>);
-        impl fmt::Debug for BoxedDiagnostic {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt::Debug::fmt(&self.0, f)
-            }
-        }
-
-        impl Diagnostic for BoxedDiagnostic {}
-
-        Box::new(BoxedDiagnostic(s))
+        Box::new(DiagnosticError(s))
     }
 }
 


### PR DESCRIPTION
Closes #435 and should just be a patch-level SemVer change!

Currently blocking the removal of `syn` from `kdl-rs`s dependency tree, but with this PR merged, that should become rather straightforward!

I also found and fixed a bug leading to compilation errors in `ffe374c`, some clippy lints, and reused some code in `53c8330`.

I also added tests wherever I was replacing `Error` or `Diagnostic` derives with something hand-written, just to be sure I wasn't changing any behavior!