### PR TITLE
Include #[diagnostic(forward(..)] in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ pub enum MyLibError {
     // Use `#[diagnostic(transparent)]` to wrap another [`Diagnostic`]. You won't see labels otherwise
     #[diagnostic(transparent)]
     AnotherError(#[from] AnotherError),
+
+    /// Forward the diagnostic to a particular field.
+    #[error("other error")]
+    #[diagnostic(forward(the_actual_diagnostic))]
+    EvenMoreData {
+        unrelated_field_1: String,
+        unrelated_field_2: usize,
+
+        #[source]
+        the_actual_diagnostic: AnotherError,
+    }
 }
 
 #[derive(Error, Diagnostic, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,17 @@
 //!     // Use `#[diagnostic(transparent)]` to wrap another [`Diagnostic`]. You won't see labels otherwise
 //!     #[diagnostic(transparent)]
 //!     AnotherError(#[from] AnotherError),
+//!
+//!     /// Forward the diagnostic to a particular field.
+//!     #[error("other error")]
+//!     #[diagnostic(forward(the_actual_diagnostic))]
+//!     EvenMoreData {
+//!         unrelated_field_1: String,
+//!         unrelated_field_2: usize,
+//!
+//!         #[source]
+//!         the_actual_diagnostic: AnotherError,
+//!     }
 //! }
 //!
 //! #[derive(Error, Diagnostic, Debug)]


### PR DESCRIPTION
I wanted the functionality `forward` provides, but could not find it in the documentation. I had to read the `miette-derive`'s source code to find it. Hopefully this will save someone else the time in the future.