### PR TITLE
chore: Use const init for Mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ rustversion = "1.0"
 trybuild = { version = "1.0.89", features = ["diff"] }
 syn = { version = "2.0.87", features = ["full"] }
 regex = "1.10"
-lazy_static = "1.4"
 
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"

--- a/tests/color_format.rs
+++ b/tests/color_format.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "fancy-no-backtrace")]
 
-use lazy_static::lazy_static;
 use miette::{Diagnostic, MietteHandler, MietteHandlerOpts, ReportHandler, RgbColors};
 use regex::Regex;
 use std::ffi::OsString;
@@ -69,9 +68,8 @@ impl Drop for EnvVarGuard<'_> {
     }
 }
 
-lazy_static! {
-    static ref COLOR_ENV_VARS: Mutex<()> = Mutex::new(());
-}
+static COLOR_ENV_VARS: Mutex<()> = Mutex::new(());
+
 
 /// Assert the color format used by a handler with different levels of terminal
 /// support.


### PR DESCRIPTION
This is available since Rust 1.63, so no change in MSRV necessary.